### PR TITLE
bolt-01: add FEN API (fen_from_starting_position, fen_is_valid, fen_roundtrip)

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -27,6 +27,38 @@ pub fn get_legal_moves(fen: &str) -> Result<Vec<String>, JsValue> {
     get_legal_moves_core(fen).map_err(|e| JsValue::from_str(&e))
 }
 
+// --- FEN API ---
+
+#[wasm_bindgen]
+pub fn fen_from_starting_position() -> String {
+    Fen::default().to_string()
+}
+
+#[wasm_bindgen]
+pub fn fen_is_valid(fen: &str) -> bool {
+    let parsed: Result<Fen, _> = fen.parse();
+    match parsed {
+        Ok(f) => f.into_position::<Chess>(CastlingMode::Standard).is_ok(),
+        Err(_) => false,
+    }
+}
+
+pub(crate) fn fen_roundtrip_inner(fen: &str) -> Result<String, String> {
+    let parsed: Fen = fen
+        .parse()
+        .map_err(|e: shakmaty::fen::ParseFenError| e.to_string())?;
+    let position = parsed
+        .into_position::<Chess>(CastlingMode::Standard)
+        .map_err(|e| e.to_string())?;
+    let fen_out = Fen::from_position(position, EnPassantMode::Legal);
+    Ok(fen_out.to_string())
+}
+
+#[wasm_bindgen]
+pub fn fen_roundtrip(fen: &str) -> Result<String, JsValue> {
+    fen_roundtrip_inner(fen).map_err(|e| JsValue::from_str(&e))
+}
+
 // --- Chess Game ---
 
 #[wasm_bindgen]
@@ -200,6 +232,50 @@ mod tests {
     fn test_stalemate_returns_empty() {
         let moves = sorted_moves("k7/8/KQ6/8/8/8/8/8 b - - 0 1");
         assert!(moves.is_empty(), "stalemate should have no legal moves");
+    }
+
+    // --- FEN API tests ---
+
+    #[test]
+    fn test_fen_starting_position() {
+        assert_eq!(
+            fen_from_starting_position(),
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        );
+    }
+
+    #[test]
+    fn test_fen_valid() {
+        assert!(fen_is_valid(
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        ));
+        assert!(fen_is_valid(
+            "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
+        ));
+    }
+
+    #[test]
+    fn test_fen_invalid() {
+        assert!(!fen_is_valid("not a fen string"));
+        assert!(!fen_is_valid(""));
+    }
+
+    #[test]
+    fn test_fen_roundtrip_valid() {
+        let input = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        assert_eq!(fen_roundtrip_inner(input).unwrap(), input);
+    }
+
+    #[test]
+    fn test_fen_roundtrip_after_e4() {
+        let input = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1";
+        let expected = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+        assert_eq!(fen_roundtrip_inner(input).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_fen_roundtrip_invalid() {
+        assert!(fen_roundtrip_inner("not a fen string").is_err());
     }
 
     // --- ChessGame tests ---

--- a/wasm/tests/fen_tests.rs
+++ b/wasm/tests/fen_tests.rs
@@ -1,0 +1,37 @@
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+use chess_wasm::{fen_from_starting_position, fen_is_valid, fen_roundtrip};
+
+#[wasm_bindgen_test]
+fn wasm_fen_from_starting_position() {
+    assert_eq!(
+        fen_from_starting_position(),
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+    );
+}
+
+#[wasm_bindgen_test]
+fn wasm_fen_is_valid_true() {
+    assert!(fen_is_valid(
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+    ));
+}
+
+#[wasm_bindgen_test]
+fn wasm_fen_is_valid_false() {
+    assert!(!fen_is_valid("not a fen"));
+}
+
+#[wasm_bindgen_test]
+fn wasm_fen_roundtrip_valid() {
+    let result = fen_roundtrip("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    assert!(result.is_ok());
+}
+
+#[wasm_bindgen_test]
+fn wasm_fen_roundtrip_invalid() {
+    let result = fen_roundtrip("not a fen");
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Closes #1

## Changes
- Added 3 FEN API functions exported via `#[wasm_bindgen]`:
  - `fen_from_starting_position()` — returns standard starting FEN
  - `fen_is_valid(fen)` — validates FEN string (parse + position legality)
  - `fen_roundtrip(fen)` — parse → Chess position → re-serialize
- Added `wasm/tests/fen_tests.rs` with wasm_bindgen_test smoke tests
- Added 6 native FEN tests to existing test module

## Test
- cargo test: 37 PASS
- bun run build: PASS

## Review
- quality-reviewer: APPROVE
- ux-reviewer: APPROVE
- architecture-reviewer: APPROVE