### PR TITLE
bolt-14: Cloudflare Pages cache headers for WASM/JS/CSS assets

### DIFF
--- a/src/public/_headers
+++ b/src/public/_headers
@@ -1,0 +1,11 @@
+/assets/*.wasm
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/*.css
+  Cache-Control: public, max-age=31536000, immutable
+
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
Closes #27

## Changes
- Add `src/public/_headers` — Cloudflare Pages cache control configuration

## Test
- bun run build: PASS
- `dist/_headers` generated and verified

## Review
- quality-reviewer: APPROVE
- ux-reviewer: APPROVE (no UI changes)
- architecture-reviewer: APPROVE