### PR TITLE
feat: undo/redo worker handlers + UI buttons (bolt-07)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useChessWorker } from "./hooks/useChessWorker";
 import { WasmErrorBoundary } from "./components/WasmErrorBoundary";
+import { UndoRedoButtons } from "./components/UndoRedoButtons";
 
 function LoadingIndicator() {
   return (
@@ -22,7 +23,7 @@ function ErrorMessage({ message }: { message: string }) {
 }
 
 function ChessApp() {
-  const { initState, renderState } = useChessWorker();
+  const { initState, renderState, sendUndo, sendRedo } = useChessWorker();
 
   switch (initState) {
     case "uninit":
@@ -35,11 +36,19 @@ function ChessApp() {
       );
     case "ready":
       return (
-        <p>
-          {renderState
-            ? `FEN: ${renderState.fen}`
-            : "Chess engine ready"}
-        </p>
+        <div>
+          <p>
+            {renderState
+              ? `FEN: ${renderState.fen}`
+              : "Chess engine ready"}
+          </p>
+          <UndoRedoButtons
+            canUndo={renderState?.canUndo ?? false}
+            canRedo={renderState?.canRedo ?? false}
+            onUndo={sendUndo}
+            onRedo={sendRedo}
+          />
+        </div>
       );
   }
 }

--- a/src/components/UndoRedoButtons.tsx
+++ b/src/components/UndoRedoButtons.tsx
@@ -1,0 +1,24 @@
+export type UndoRedoButtonsProps = {
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+};
+
+export function UndoRedoButtons({
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+}: UndoRedoButtonsProps) {
+  return (
+    <div>
+      <button type="button" disabled={!canUndo} onClick={onUndo}>
+        Undo
+      </button>
+      <button type="button" disabled={!canRedo} onClick={onRedo}>
+        Redo
+      </button>
+    </div>
+  );
+}

--- a/src/components/__tests__/UndoRedoButtons.test.tsx
+++ b/src/components/__tests__/UndoRedoButtons.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { UndoRedoButtons } from "../UndoRedoButtons";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("UndoRedoButtons", () => {
+  it("renders Undo and Redo buttons", () => {
+    render(
+      <UndoRedoButtons
+        canUndo={false}
+        canRedo={false}
+        onUndo={vi.fn()}
+        onRedo={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: /undo/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /redo/i })).toBeDefined();
+  });
+
+  it("Undo button is disabled when canUndo is false", () => {
+    render(
+      <UndoRedoButtons
+        canUndo={false}
+        canRedo={true}
+        onUndo={vi.fn()}
+        onRedo={vi.fn()}
+      />
+    );
+    const undoBtn = screen.getByRole("button", { name: /undo/i });
+    expect(undoBtn).toHaveProperty("disabled", true);
+  });
+
+  it("Redo button is disabled when canRedo is false", () => {
+    render(
+      <UndoRedoButtons
+        canUndo={true}
+        canRedo={false}
+        onUndo={vi.fn()}
+        onRedo={vi.fn()}
+      />
+    );
+    const redoBtn = screen.getByRole("button", { name: /redo/i });
+    expect(redoBtn).toHaveProperty("disabled", true);
+  });
+
+  it("Undo button is enabled when canUndo is true", () => {
+    render(
+      <UndoRedoButtons
+        canUndo={true}
+        canRedo={false}
+        onUndo={vi.fn()}
+        onRedo={vi.fn()}
+      />
+    );
+    const undoBtn = screen.getByRole("button", { name: /undo/i });
+    expect(undoBtn).toHaveProperty("disabled", false);
+  });
+
+  it("Redo button is enabled when canRedo is true", () => {
+    render(
+      <UndoRedoButtons
+        canUndo={false}
+        canRedo={true}
+        onUndo={vi.fn()}
+        onRedo={vi.fn()}
+      />
+    );
+    const redoBtn = screen.getByRole("button", { name: /redo/i });
+    expect(redoBtn).toHaveProperty("disabled", false);
+  });
+
+  it("calls onUndo when Undo button is clicked", () => {
+    const onUndo = vi.fn();
+    render(
+      <UndoRedoButtons
+        canUndo={true}
+        canRedo={false}
+        onUndo={onUndo}
+        onRedo={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /undo/i }));
+    expect(onUndo).toHaveBeenCalledOnce();
+  });
+
+  it("calls onRedo when Redo button is clicked", () => {
+    const onRedo = vi.fn();
+    render(
+      <UndoRedoButtons
+        canUndo={false}
+        canRedo={true}
+        onUndo={vi.fn()}
+        onRedo={onRedo}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /redo/i }));
+    expect(onRedo).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onUndo when Undo button is disabled and clicked", () => {
+    const onUndo = vi.fn();
+    render(
+      <UndoRedoButtons
+        canUndo={false}
+        canRedo={false}
+        onUndo={onUndo}
+        onRedo={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /undo/i }));
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+
+  it("does not call onRedo when Redo button is disabled and clicked", () => {
+    const onRedo = vi.fn();
+    render(
+      <UndoRedoButtons
+        canUndo={false}
+        canRedo={false}
+        onUndo={vi.fn()}
+        onRedo={onRedo}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /redo/i }));
+    expect(onRedo).not.toHaveBeenCalled();
+  });
+});

--- a/src/worker/__tests__/chess.worker.test.ts
+++ b/src/worker/__tests__/chess.worker.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { WorkerRequest, WorkerResponse } from "../types";
+import type { RenderState } from "../../types/chess";
+import { GameStatus } from "../../types/chess";
 
 // We test the worker's onmessage handler in isolation by importing the module
 // and simulating the worker environment.
@@ -10,49 +12,192 @@ const mockPostMessage = vi.fn();
 // We'll set up a fake worker global scope
 vi.stubGlobal("postMessage", mockPostMessage);
 
+// Mock ChessGame from WASM
+const mockChessGame = {
+  current_fen: vi.fn(
+    () => "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  ),
+  game_status: vi.fn(() => GameStatus.InProgress),
+  can_undo: vi.fn(() => false),
+  can_redo: vi.fn(() => false),
+  apply_move: vi.fn(),
+  undo: vi.fn(() => true),
+  redo: vi.fn(() => true),
+};
+
+const mockGetLegalMoves = vi.fn((_fen: string) => ["e2e3", "e2e4", "d2d3", "d2d4"]);
+
+vi.mock("../../../wasm-pkg/chess_wasm", () => {
+  return {
+    default: vi.fn(() => Promise.resolve()),
+    ChessGame: class {
+      current_fen = mockChessGame.current_fen;
+      game_status = mockChessGame.game_status;
+      can_undo = mockChessGame.can_undo;
+      can_redo = mockChessGame.can_redo;
+      apply_move = mockChessGame.apply_move;
+      undo = mockChessGame.undo;
+      redo = mockChessGame.redo;
+    },
+    get_legal_moves: (fen: string) => mockGetLegalMoves(fen),
+  };
+});
+
 // Dynamically import the worker module after mocking
-let handleMessage: (event: MessageEvent<WorkerRequest>) => void;
+let handleMessage: (event: MessageEvent<WorkerRequest>) => Promise<void>;
 
 beforeEach(async () => {
   mockPostMessage.mockClear();
+  vi.clearAllMocks();
+
+  // Reset default mock return values
+  mockChessGame.current_fen.mockReturnValue(
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  );
+  mockGetLegalMoves.mockReturnValue(["e2e3", "e2e4", "d2d3", "d2d4"]);
+  mockChessGame.game_status.mockReturnValue(GameStatus.InProgress);
+  mockChessGame.can_undo.mockReturnValue(false);
+  mockChessGame.can_redo.mockReturnValue(false);
+  mockChessGame.apply_move.mockReturnValue(undefined);
+  mockChessGame.undo.mockReturnValue(true);
+  mockChessGame.redo.mockReturnValue(true);
+
+  // Reset modules to get a fresh game=null state for each test
+  vi.resetModules();
   // Import the handler function exported for testing
   const mod = await import("../chess.worker");
   handleMessage = mod.handleMessage;
 });
 
+function expectRenderState(expected: Partial<RenderState>): void {
+  expect(mockPostMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "STATE_UPDATE",
+      payload: expect.objectContaining(expected),
+    })
+  );
+}
+
 describe("chess.worker message routing", () => {
-  it("responds READY to INIT", () => {
-    handleMessage(new MessageEvent("message", { data: { type: "INIT" } }));
+  it("responds READY to INIT and initializes ChessGame", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
     expect(mockPostMessage).toHaveBeenCalledWith({
       type: "READY",
     } satisfies WorkerResponse);
   });
 
-  it("responds ERROR to APPLY_MOVE (not implemented)", () => {
-    handleMessage(
+  it("responds STATE_UPDATE to APPLY_MOVE with valid move", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    mockPostMessage.mockClear();
+
+    mockChessGame.can_undo.mockReturnValue(true);
+
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "APPLY_MOVE", payload: { uciMove: "e2e4" } },
+      })
+    );
+
+    expect(mockChessGame.apply_move).toHaveBeenCalledWith("e2e4");
+    expectRenderState({ canUndo: true });
+  });
+
+  it("responds ERROR to APPLY_MOVE with invalid move", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    mockPostMessage.mockClear();
+
+    mockChessGame.apply_move.mockImplementation(() => {
+      throw new Error("Illegal move");
+    });
+
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "APPLY_MOVE", payload: { uciMove: "e2e5" } },
+      })
+    );
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: "ERROR",
+      payload: { message: "Illegal move" },
+    } satisfies WorkerResponse);
+  });
+
+  it("responds STATE_UPDATE to UNDO", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    mockPostMessage.mockClear();
+
+    mockChessGame.can_redo.mockReturnValue(true);
+
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "UNDO" } })
+    );
+
+    expect(mockChessGame.undo).toHaveBeenCalled();
+    expectRenderState({ canRedo: true });
+  });
+
+  it("responds STATE_UPDATE to REDO", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    mockPostMessage.mockClear();
+
+    mockChessGame.can_undo.mockReturnValue(true);
+
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "REDO" } })
+    );
+
+    expect(mockChessGame.redo).toHaveBeenCalled();
+    expectRenderState({ canUndo: true });
+  });
+
+  it("responds ERROR when UNDO/REDO called before INIT", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "UNDO" } })
+    );
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: "ERROR",
+      payload: { message: "Game not initialized" },
+    } satisfies WorkerResponse);
+  });
+
+  it("responds ERROR when APPLY_MOVE called before INIT", async () => {
+    await handleMessage(
       new MessageEvent("message", {
         data: { type: "APPLY_MOVE", payload: { uciMove: "e2e4" } },
       })
     );
     expect(mockPostMessage).toHaveBeenCalledWith({
       type: "ERROR",
-      payload: { message: "not implemented" },
+      payload: { message: "Game not initialized" },
     } satisfies WorkerResponse);
   });
 
-  it("responds ERROR to UNDO (not implemented)", () => {
-    handleMessage(new MessageEvent("message", { data: { type: "UNDO" } }));
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: "ERROR",
-      payload: { message: "not implemented" },
-    } satisfies WorkerResponse);
-  });
+  it("canUndo and canRedo are correctly reported in render state", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    mockPostMessage.mockClear();
 
-  it("responds ERROR to REDO (not implemented)", () => {
-    handleMessage(new MessageEvent("message", { data: { type: "REDO" } }));
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: "ERROR",
-      payload: { message: "not implemented" },
-    } satisfies WorkerResponse);
+    // After a move: canUndo=true, canRedo=false
+    mockChessGame.can_undo.mockReturnValue(true);
+    mockChessGame.can_redo.mockReturnValue(false);
+
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "APPLY_MOVE", payload: { uciMove: "e2e4" } },
+      })
+    );
+
+    expectRenderState({ canUndo: true, canRedo: false });
   });
 });

--- a/src/worker/chess.worker.ts
+++ b/src/worker/chess.worker.ts
@@ -1,36 +1,82 @@
 import type { WorkerRequest, WorkerResponse } from "./types";
+import type { RenderState } from "../types/chess";
+import init, { ChessGame, get_legal_moves } from "../../wasm-pkg/chess_wasm";
+
+let game: ChessGame | null = null;
 
 function postResponse(response: WorkerResponse): void {
   postMessage(response);
 }
 
-export function handleMessage(event: MessageEvent<WorkerRequest>): void {
+function buildRenderState(): RenderState {
+  if (!game) throw new Error("Game not initialized");
+  const fen = game.current_fen();
+  return {
+    fen,
+    legalMoves: get_legal_moves(fen),
+    status: game.game_status(),
+    canUndo: game.can_undo(),
+    canRedo: game.can_redo(),
+  };
+}
+
+export async function handleMessage(
+  event: MessageEvent<WorkerRequest>
+): Promise<void> {
   const { data } = event;
 
   switch (data.type) {
-    case "INIT":
+    case "INIT": {
+      await init();
+      game = new ChessGame();
       postResponse({ type: "READY" });
       break;
-    case "APPLY_MOVE":
-      postResponse({
-        type: "ERROR",
-        payload: { message: "not implemented" },
-      });
+    }
+    case "APPLY_MOVE": {
+      if (!game) {
+        postResponse({
+          type: "ERROR",
+          payload: { message: "Game not initialized" },
+        });
+        return;
+      }
+      try {
+        game.apply_move(data.payload.uciMove);
+        postResponse({ type: "STATE_UPDATE", payload: buildRenderState() });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        postResponse({ type: "ERROR", payload: { message } });
+      }
       break;
-    case "UNDO":
-      postResponse({
-        type: "ERROR",
-        payload: { message: "not implemented" },
-      });
+    }
+    case "UNDO": {
+      if (!game) {
+        postResponse({
+          type: "ERROR",
+          payload: { message: "Game not initialized" },
+        });
+        return;
+      }
+      game.undo();
+      postResponse({ type: "STATE_UPDATE", payload: buildRenderState() });
       break;
-    case "REDO":
-      postResponse({
-        type: "ERROR",
-        payload: { message: "not implemented" },
-      });
+    }
+    case "REDO": {
+      if (!game) {
+        postResponse({
+          type: "ERROR",
+          payload: { message: "Game not initialized" },
+        });
+        return;
+      }
+      game.redo();
+      postResponse({ type: "STATE_UPDATE", payload: buildRenderState() });
       break;
+    }
   }
 }
 
 // Attach to self.onmessage when running as a Web Worker
-onmessage = handleMessage;
+onmessage = (event: MessageEvent<WorkerRequest>) => {
+  void handleMessage(event);
+};


### PR DESCRIPTION
## Summary
- Wire up `chess.worker.ts` to call WASM `ChessGame` API for `undo`, `redo`, and `apply_move`, returning `RenderState` with `canUndo`/`canRedo` flags
- Add `UndoRedoButtons` component with proper disabled state management based on `canUndo`/`canRedo`
- Integrate `UndoRedoButtons` into `App.tsx` with `sendUndo`/`sendRedo` from `useChessWorker`

## Test plan
- [x] Worker tests: UNDO/REDO messages return STATE_UPDATE with correct canUndo/canRedo
- [x] Worker tests: APPLY_MOVE error handling (invalid move returns ERROR)
- [x] Worker tests: operations before INIT return "Game not initialized" error
- [x] UndoRedoButtons tests: Undo/Redo buttons disabled when canUndo/canRedo is false
- [x] UndoRedoButtons tests: click handlers fire correctly, do not fire when disabled
- [x] All 42 tests pass (`bun run test`)
- [x] Build succeeds (`bun run build`)
- [x] TypeScript strict mode passes (`tsc --noEmit`)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)