### PR TITLE
bolt-22: WASM binary size guardrail in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   deploy:
@@ -26,7 +29,37 @@ jobs:
 
       - run: bun run build
 
-      - uses: cloudflare/wrangler-action@v3
+      - name: Report WASM binary size
+        id: wasm-size
+        run: |
+          set -euo pipefail
+          WASM_FILE=$(find ./wasm/pkg -name "*.wasm" | head -1)
+          if [ -z "$WASM_FILE" ]; then
+            echo "ERROR: No .wasm file found in ./wasm/pkg"
+            exit 1
+          fi
+          RAW_SIZE=$(wc -c < "$WASM_FILE")
+          GZIP_SIZE=$(gzip -c "$WASM_FILE" | wc -c)
+          GZIP_KB=$((GZIP_SIZE / 1024))
+          echo "WASM raw size: ${RAW_SIZE} bytes"
+          echo "WASM gzip size: ${GZIP_SIZE} bytes (${GZIP_KB} KB)"
+          echo "wasm_gzip_kb=${GZIP_KB}" >> $GITHUB_OUTPUT
+          echo "## WASM Binary Size" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          echo "| Raw size | ${RAW_SIZE} bytes |" >> $GITHUB_STEP_SUMMARY
+          echo "| Gzip size | ${GZIP_SIZE} bytes (${GZIP_KB} KB) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Threshold | 500 KB |" >> $GITHUB_STEP_SUMMARY
+          THRESHOLD=500
+          if [ "$GZIP_KB" -ge "$THRESHOLD" ]; then
+            echo "| Status | FAIL: ${GZIP_KB}KB exceeds ${THRESHOLD}KB |" >> $GITHUB_STEP_SUMMARY
+            echo "ERROR: WASM gzip size ${GZIP_KB}KB exceeds threshold ${THRESHOLD}KB"
+            exit 1
+          fi
+          echo "| Status | PASS: ${GZIP_KB}KB within ${THRESHOLD}KB |" >> $GITHUB_STEP_SUMMARY
+
+      - if: github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Closes #37

## Changes
- Add `pull_request` trigger to deploy workflow
- Add "Report WASM binary size" step after `bun run build`
  - Fails (`exit 1`) if gzip size >= 500KB
  - Reports to `$GITHUB_STEP_SUMMARY` as markdown table
- Guard Cloudflare deploy to `main` branch only (skipped on PRs)

## Test
- bun run build: PASS
- Workflow YAML validated

## Review
- quality-reviewer: APPROVE (after 1 revision — set -euo pipefail + -ge threshold fix)
- ux-reviewer: APPROVE (no UI changes)
- architecture-reviewer: APPROVE