### PR TITLE
bolt: Web Worker + WASM 通信レイヤー (init / apply_move / render_state)

### DIFF
--- a/src/hooks/__tests__/useChessWorker.test.ts
+++ b/src/hooks/__tests__/useChessWorker.test.ts
@@ -27,6 +27,21 @@ vi.mock("../../worker/chess.worker?worker", () => {
   };
 });
 
+const INIT_STATE_UPDATE: WorkerResponse = {
+  type: "STATE_UPDATE",
+  payload: {
+    fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    legalMoves: [],
+    status: 0,
+    canUndo: false,
+    canRedo: false,
+  },
+};
+
+function sendStateUpdate(payload = INIT_STATE_UPDATE) {
+  workerInstance.onmessage?.(new MessageEvent("message", { data: payload }));
+}
+
 describe("useChessWorker", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,13 +65,11 @@ describe("useChessWorker", () => {
     expect(workerInstance.postMessage).toHaveBeenCalledWith({ type: "INIT" });
   });
 
-  it("transitions to ready on READY message", () => {
+  it("transitions to ready on first STATE_UPDATE (INIT response)", () => {
     const { result } = renderHook(() => useChessWorker());
 
     act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
+      sendStateUpdate(INIT_STATE_UPDATE);
     });
 
     expect(result.current.initState).toBe("ready");
@@ -80,10 +93,9 @@ describe("useChessWorker", () => {
   it("stores lastError on post-init ERROR without changing initState", () => {
     const { result } = renderHook(() => useChessWorker());
 
+    // Become ready via STATE_UPDATE
     act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
+      sendStateUpdate(INIT_STATE_UPDATE);
     });
 
     act(() => {
@@ -100,13 +112,6 @@ describe("useChessWorker", () => {
 
   it("updates renderState on STATE_UPDATE message", () => {
     const { result } = renderHook(() => useChessWorker());
-
-    // First become ready
-    act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
-    });
 
     act(() => {
       workerInstance.onmessage?.(
@@ -132,16 +137,13 @@ describe("useChessWorker", () => {
       canUndo: false,
       canRedo: false,
     });
+    expect(result.current.initState).toBe("ready");
   });
 
   it("sendMove posts APPLY_MOVE to worker", () => {
     const { result } = renderHook(() => useChessWorker());
 
-    act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
-    });
+    act(() => { sendStateUpdate(); });
 
     act(() => {
       result.current.sendMove("e2e4");
@@ -156,11 +158,7 @@ describe("useChessWorker", () => {
   it("sendUndo posts UNDO to worker", () => {
     const { result } = renderHook(() => useChessWorker());
 
-    act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
-    });
+    act(() => { sendStateUpdate(); });
 
     act(() => {
       result.current.sendUndo();
@@ -172,11 +170,7 @@ describe("useChessWorker", () => {
   it("sendRedo posts REDO to worker", () => {
     const { result } = renderHook(() => useChessWorker());
 
-    act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
-    });
+    act(() => { sendStateUpdate(); });
 
     act(() => {
       result.current.sendRedo();

--- a/src/hooks/useChessWorker.ts
+++ b/src/hooks/useChessWorker.ts
@@ -13,7 +13,6 @@ interface State {
 
 type Action =
   | { type: "START_INIT" }
-  | { type: "READY" }
   | { type: "ERROR"; message: string }
   | { type: "STATE_UPDATE"; payload: RenderState };
 
@@ -22,17 +21,17 @@ function reducer(state: State, action: Action): State {
     case "START_INIT":
       if (state.initState !== "uninit") return state;
       return { ...state, initState: "initializing" };
-    case "READY":
-      if (state.initState !== "initializing") return state;
-      return { ...state, initState: "ready" };
     case "ERROR":
       if (state.initState === "initializing") {
         return { ...state, initState: "error", lastError: action.message };
       }
       // Post-init errors (APPLY_MOVE, UNDO, REDO): store message without state change
       return { ...state, lastError: action.message };
-    case "STATE_UPDATE":
-      return { ...state, renderState: action.payload };
+    case "STATE_UPDATE": {
+      const initState =
+        state.initState === "initializing" ? "ready" : state.initState;
+      return { ...state, initState, renderState: action.payload };
+    }
     default:
       return state;
   }
@@ -64,9 +63,6 @@ export function useChessWorker(): UseChessWorkerReturn {
     worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
       const msg = event.data;
       switch (msg.type) {
-        case "READY":
-          dispatch({ type: "READY" });
-          break;
         case "STATE_UPDATE":
           dispatch({ type: "STATE_UPDATE", payload: msg.payload });
           break;

--- a/src/worker/__tests__/chess.worker.test.ts
+++ b/src/worker/__tests__/chess.worker.test.ts
@@ -1,38 +1,194 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { WorkerRequest, WorkerResponse } from "../types";
+import { GameStatus } from "../../types/chess";
 
-// We test the worker's onmessage handler in isolation by importing the module
-// and simulating the worker environment.
+const STARTING_FEN =
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+const AFTER_E2E4_FEN =
+  "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
 
-// Mock self.postMessage
+// --- Mock WASM module ---
+
+class MockChessGame {
+  private fen = STARTING_FEN;
+  private undoStack: string[] = [];
+
+  current_fen() {
+    return this.fen;
+  }
+  apply_move(uciMove: string) {
+    if (uciMove === "e2e4") {
+      this.undoStack.push(this.fen);
+      this.fen = AFTER_E2E4_FEN;
+    } else {
+      throw new Error(`Illegal move: ${uciMove}`);
+    }
+  }
+  game_status() {
+    return GameStatus.InProgress;
+  }
+  can_undo() {
+    return this.undoStack.length > 0;
+  }
+  can_redo() {
+    return false;
+  }
+}
+
+const mockInitFn = vi.fn().mockResolvedValue(undefined);
+const mockGetLegalMoves = vi.fn().mockReturnValue(Array(20).fill("e2e4"));
+let mockGameInstance: MockChessGame;
+
+vi.mock("../../../wasm-pkg/chess_wasm", () => ({
+  default: mockInitFn,
+  // eslint-disable-next-line func-style
+  ChessGame: vi.fn().mockImplementation(function () {
+    return mockGameInstance;
+  }),
+  get_legal_moves: mockGetLegalMoves,
+}));
+
+// --- Mock self.postMessage ---
+
 const mockPostMessage = vi.fn();
-
-// We'll set up a fake worker global scope
 vi.stubGlobal("postMessage", mockPostMessage);
 
-// Dynamically import the worker module after mocking
-let handleMessage: (event: MessageEvent<WorkerRequest>) => void;
+// --- Import handler ---
+
+let handleMessage: (event: MessageEvent<WorkerRequest>) => Promise<void>;
 
 beforeEach(async () => {
   mockPostMessage.mockClear();
-  // Import the handler function exported for testing
+  mockInitFn.mockResolvedValue(undefined);
+  mockGameInstance = new MockChessGame();
+  vi.resetModules();
   const mod = await import("../chess.worker");
   handleMessage = mod.handleMessage;
 });
 
-describe("chess.worker message routing", () => {
-  it("responds READY to INIT", () => {
-    handleMessage(new MessageEvent("message", { data: { type: "INIT" } }));
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: "READY",
-    } satisfies WorkerResponse);
+describe("INIT", () => {
+  it("responds STATE_UPDATE on successful init", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    expect(mockPostMessage).toHaveBeenCalledOnce();
+    const response = mockPostMessage.mock.calls[0][0] as WorkerResponse;
+    expect(response.type).toBe("STATE_UPDATE");
   });
 
-  it("responds ERROR to APPLY_MOVE (not implemented)", () => {
-    handleMessage(
+  it("STATE_UPDATE contains starting FEN", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    const response = mockPostMessage.mock.calls[0][0] as WorkerResponse;
+    if (response.type !== "STATE_UPDATE") throw new Error("wrong type");
+    expect(response.payload.fen).toBe(STARTING_FEN);
+  });
+
+  it("STATE_UPDATE has 20 legal moves", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    const response = mockPostMessage.mock.calls[0][0] as WorkerResponse;
+    if (response.type !== "STATE_UPDATE") throw new Error("wrong type");
+    expect(response.payload.legalMoves).toHaveLength(20);
+  });
+
+  it("STATE_UPDATE has status InProgress", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    const response = mockPostMessage.mock.calls[0][0] as WorkerResponse;
+    if (response.type !== "STATE_UPDATE") throw new Error("wrong type");
+    expect(response.payload.status).toBe(GameStatus.InProgress);
+  });
+
+  it("STATE_UPDATE has canUndo=false, canRedo=false", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    const response = mockPostMessage.mock.calls[0][0] as WorkerResponse;
+    if (response.type !== "STATE_UPDATE") throw new Error("wrong type");
+    expect(response.payload.canUndo).toBe(false);
+    expect(response.payload.canRedo).toBe(false);
+  });
+
+  it("responds ERROR when WASM init fails", async () => {
+    mockInitFn.mockRejectedValueOnce(new Error("wasm load failed"));
+
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    const response = mockPostMessage.mock.calls[0][0] as WorkerResponse;
+    expect(response.type).toBe("ERROR");
+  });
+});
+
+describe("APPLY_MOVE", () => {
+  it("responds STATE_UPDATE with updated FEN on legal move", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    mockPostMessage.mockClear();
+
+    await handleMessage(
       new MessageEvent("message", {
         data: { type: "APPLY_MOVE", payload: { uciMove: "e2e4" } },
       })
+    );
+    const response = mockPostMessage.mock.calls[0][0] as WorkerResponse;
+    expect(response.type).toBe("STATE_UPDATE");
+    if (response.type !== "STATE_UPDATE") throw new Error("wrong type");
+    expect(response.payload.fen).toBe(AFTER_E2E4_FEN);
+  });
+
+  it("responds ERROR on illegal move without crashing", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    mockPostMessage.mockClear();
+
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "APPLY_MOVE", payload: { uciMove: "e2e9" } },
+      })
+    );
+    const response = mockPostMessage.mock.calls[0][0] as WorkerResponse;
+    expect(response.type).toBe("ERROR");
+  });
+
+  it("subsequent call still works after ERROR (worker does not crash)", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "APPLY_MOVE", payload: { uciMove: "invalid" } },
+      })
+    );
+
+    mockPostMessage.mockClear();
+
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "APPLY_MOVE", payload: { uciMove: "e2e4" } },
+      })
+    );
+    const response = mockPostMessage.mock.calls[0][0] as WorkerResponse;
+    expect(response.type).toBe("STATE_UPDATE");
+  });
+});
+
+describe("UNDO / REDO (not yet implemented in bolt-05)", () => {
+  it("responds ERROR to UNDO", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    mockPostMessage.mockClear();
+
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "UNDO" } })
     );
     expect(mockPostMessage).toHaveBeenCalledWith({
       type: "ERROR",
@@ -40,16 +196,15 @@ describe("chess.worker message routing", () => {
     } satisfies WorkerResponse);
   });
 
-  it("responds ERROR to UNDO (not implemented)", () => {
-    handleMessage(new MessageEvent("message", { data: { type: "UNDO" } }));
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: "ERROR",
-      payload: { message: "not implemented" },
-    } satisfies WorkerResponse);
-  });
+  it("responds ERROR to REDO", async () => {
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "INIT" } })
+    );
+    mockPostMessage.mockClear();
 
-  it("responds ERROR to REDO (not implemented)", () => {
-    handleMessage(new MessageEvent("message", { data: { type: "REDO" } }));
+    await handleMessage(
+      new MessageEvent("message", { data: { type: "REDO" } })
+    );
     expect(mockPostMessage).toHaveBeenCalledWith({
       type: "ERROR",
       payload: { message: "not implemented" },

--- a/src/worker/__tests__/types.test.ts
+++ b/src/worker/__tests__/types.test.ts
@@ -31,11 +31,6 @@ describe("WorkerRequest discriminated union", () => {
 });
 
 describe("WorkerResponse discriminated union", () => {
-  it("allows READY response", () => {
-    const resp: WorkerResponse = { type: "READY" };
-    expect(resp.type).toBe("READY");
-  });
-
   it("allows STATE_UPDATE response with RenderState payload", () => {
     const resp: WorkerResponse = {
       type: "STATE_UPDATE",

--- a/src/worker/chess.worker.ts
+++ b/src/worker/chess.worker.ts
@@ -1,33 +1,65 @@
+import type { RenderState } from "../types/chess";
 import type { WorkerRequest, WorkerResponse } from "./types";
+
+type WasmModule = typeof import("../../wasm-pkg/chess_wasm");
+type ChessGameInstance = InstanceType<WasmModule["ChessGame"]>;
+
+let wasm: WasmModule | null = null;
+let game: ChessGameInstance | null = null;
 
 function postResponse(response: WorkerResponse): void {
   postMessage(response);
 }
 
-export function handleMessage(event: MessageEvent<WorkerRequest>): void {
+function postError(e: unknown): void {
+  postResponse({ type: "ERROR", payload: { message: String(e) } });
+}
+
+function buildRenderState(): RenderState {
+  if (!wasm || !game) throw new Error("WASM not initialized");
+  const fen = game.current_fen();
+  return {
+    fen,
+    legalMoves: Array.from(wasm.get_legal_moves(fen)),
+    status: game.game_status(),
+    canUndo: game.can_undo(),
+    canRedo: game.can_redo(),
+  };
+}
+
+export async function handleMessage(
+  event: MessageEvent<WorkerRequest>
+): Promise<void> {
   const { data } = event;
 
   switch (data.type) {
-    case "INIT":
-      postResponse({ type: "READY" });
+    case "INIT": {
+      try {
+        const mod = await import("../../wasm-pkg/chess_wasm");
+        await mod.default();
+        wasm = mod;
+        game = new mod.ChessGame();
+        postResponse({ type: "STATE_UPDATE", payload: buildRenderState() });
+      } catch (e) {
+        postError(e);
+      }
       break;
-    case "APPLY_MOVE":
-      postResponse({
-        type: "ERROR",
-        payload: { message: "not implemented" },
-      });
+    }
+    case "APPLY_MOVE": {
+      try {
+        if (!wasm || !game) throw new Error("Not initialized");
+        game.apply_move(data.payload.uciMove);
+        postResponse({ type: "STATE_UPDATE", payload: buildRenderState() });
+      } catch (e) {
+        postError(e);
+      }
       break;
+    }
     case "UNDO":
-      postResponse({
-        type: "ERROR",
-        payload: { message: "not implemented" },
-      });
+      postError("not implemented");
       break;
     case "REDO":
-      postResponse({
-        type: "ERROR",
-        payload: { message: "not implemented" },
-      });
+      postError("not implemented");
       break;
   }
 }

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -7,6 +7,5 @@ export type WorkerRequest =
   | { type: "REDO" };
 
 export type WorkerResponse =
-  | { type: "READY" }
   | { type: "STATE_UPDATE"; payload: RenderState }
   | { type: "ERROR"; payload: { message: string } };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import wasm from "vite-plugin-wasm";
 export default defineConfig({
   root: "src",
   plugins: [react(), wasm()],
+  worker: {
+    format: "es",
+    plugins: () => [wasm()],
+  },
   build: {
     target: "esnext",
     outDir: "../dist",


### PR DESCRIPTION
Closes #5

## Changes

- `chess.worker.ts`: INIT handler dynamically imports `chess_wasm` WASM, initializes `ChessGame`, returns `STATE_UPDATE` with initial `RenderState`; APPLY_MOVE calls `game.apply_move()`, returns `STATE_UPDATE` on success or `ERROR` on failure
- `chess.worker.ts`: extracted `postError()` helper; added `!wasm` guard to APPLY_MOVE
- `worker/types.ts`: removed unused `READY` from `WorkerResponse` (never emitted)
- `useChessWorker.ts`: `STATE_UPDATE` during `"initializing"` now transitions to `"ready"` (no separate READY message)
- `vite.config.ts`: `worker.format: "es"` for dynamic import support in Web Worker

## Test

- cargo test: PASS (no Rust changes)
- bun run test: PASS (35 tests)
- bun run build: PASS