### PR TITLE
fix: WASM コントラクト修正 — GameStatus 4値化 + render_state() API (bolt-23)

### DIFF
--- a/src/types/__tests__/chess.test.ts
+++ b/src/types/__tests__/chess.test.ts
@@ -7,38 +7,39 @@ describe("GameStatus const enum", () => {
     expect(GameStatus.InProgress).toBe(0);
   });
 
-  it("has Check = 1", () => {
-    expect(GameStatus.Check).toBe(1);
+  it("has Checkmate = 1", () => {
+    expect(GameStatus.Checkmate).toBe(1);
   });
 
-  it("has Checkmate = 2", () => {
-    expect(GameStatus.Checkmate).toBe(2);
+  it("has Stalemate = 2", () => {
+    expect(GameStatus.Stalemate).toBe(2);
   });
 
-  it("has Stalemate = 3", () => {
-    expect(GameStatus.Stalemate).toBe(3);
+  it("has Draw = 3", () => {
+    expect(GameStatus.Draw).toBe(3);
   });
 
-  it("has Draw = 4", () => {
-    expect(GameStatus.Draw).toBe(4);
+  it("does not have Check", () => {
+    expect((GameStatus as Record<string, unknown>)["Check"]).toBeUndefined();
   });
 });
 
 describe("RenderState", () => {
-  it("satisfies the interface shape", () => {
+  it("satisfies the interface shape with all required fields", () => {
     const state: RenderState = {
       fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      board: { e1: "K", d1: "Q" },
       legalMoves: ["e2e4", "d2d4"],
       status: GameStatus.InProgress,
+      isCheck: false,
       canUndo: false,
       canRedo: false,
+      currentTurn: "white",
     };
-    expect(state.fen).toBe(
-      "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-    );
-    expect(state.legalMoves).toEqual(["e2e4", "d2d4"]);
+    expect(state.fen).toBeTruthy();
+    expect(state.board).toEqual({ e1: "K", d1: "Q" });
+    expect(state.isCheck).toBe(false);
+    expect(state.currentTurn).toBe("white");
     expect(state.status).toBe(GameStatus.InProgress);
-    expect(state.canUndo).toBe(false);
-    expect(state.canRedo).toBe(false);
   });
 });

--- a/src/types/chess.ts
+++ b/src/types/chess.ts
@@ -1,15 +1,17 @@
 export enum GameStatus {
   InProgress = 0,
-  Check = 1,
-  Checkmate = 2,
-  Stalemate = 3,
-  Draw = 4,
+  Checkmate = 1,
+  Stalemate = 2,
+  Draw = 3,
 }
 
 export interface RenderState {
   fen: string;
+  board: Record<string, string>;
   legalMoves: string[];
   status: GameStatus;
+  isCheck: boolean;
   canUndo: boolean;
   canRedo: boolean;
+  currentTurn: "white" | "black";
 }

--- a/src/worker/__tests__/chess.worker.test.ts
+++ b/src/worker/__tests__/chess.worker.test.ts
@@ -47,6 +47,18 @@ class MockChessGame {
       this.fen = this.redoStack.pop()!;
     }
   }
+  render_state() {
+    return {
+      fen: this.fen,
+      board: {},
+      legalMoves: ["e2e4"],
+      status: GameStatus.InProgress,
+      isCheck: false,
+      canUndo: this.can_undo(),
+      canRedo: this.can_redo(),
+      currentTurn: "white" as const,
+    };
+  }
 }
 
 const mockInitFn = vi.fn().mockResolvedValue(undefined);

--- a/src/worker/chess.worker.ts
+++ b/src/worker/chess.worker.ts
@@ -4,23 +4,15 @@ import type { WorkerRequest, WorkerResponse } from "./types";
 type WasmModule = typeof import("../../wasm-pkg/chess_wasm");
 type ChessGameInstance = InstanceType<WasmModule["ChessGame"]>;
 
-let wasm: WasmModule | null = null;
 let game: ChessGameInstance | null = null;
 
 function postResponse(response: WorkerResponse): void {
   postMessage(response);
 }
 
-function buildRenderState(): RenderState {
-  if (!wasm || !game) throw new Error("WASM not initialized");
-  const fen = game.current_fen();
-  return {
-    fen,
-    legalMoves: Array.from(wasm.get_legal_moves(fen)),
-    status: game.game_status(),
-    canUndo: game.can_undo(),
-    canRedo: game.can_redo(),
-  };
+function getRenderState(): RenderState {
+  if (!game) throw new Error("Game not initialized");
+  return game.render_state() as unknown as RenderState;
 }
 
 export async function handleMessage(
@@ -33,9 +25,8 @@ export async function handleMessage(
       try {
         const mod = await import("../../wasm-pkg/chess_wasm");
         await mod.default();
-        wasm = mod;
         game = new mod.ChessGame();
-        postResponse({ type: "STATE_UPDATE", payload: buildRenderState() });
+        postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({
           type: "ERROR",
@@ -46,9 +37,9 @@ export async function handleMessage(
     }
     case "APPLY_MOVE": {
       try {
-        if (!game) throw new Error("Not initialized");
+        if (!game) throw new Error("Game not initialized");
         game.apply_move(data.payload.uciMove);
-        postResponse({ type: "STATE_UPDATE", payload: buildRenderState() });
+        postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({
           type: "ERROR",
@@ -59,9 +50,9 @@ export async function handleMessage(
     }
     case "UNDO": {
       try {
-        if (!game) throw new Error("Not initialized");
+        if (!game) throw new Error("Game not initialized");
         game.undo();
-        postResponse({ type: "STATE_UPDATE", payload: buildRenderState() });
+        postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({
           type: "ERROR",
@@ -72,9 +63,9 @@ export async function handleMessage(
     }
     case "REDO": {
       try {
-        if (!game) throw new Error("Not initialized");
+        if (!game) throw new Error("Game not initialized");
         game.redo();
-        postResponse({ type: "STATE_UPDATE", payload: buildRenderState() });
+        postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({
           type: "ERROR",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -72,9 +72,22 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "chess-wasm"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
+ "serde",
+ "serde-wasm-bindgen",
  "shakmaty",
  "wasm-bindgen",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -229,6 +242,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -9,6 +9,9 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 shakmaty = "0.27"
+console_error_panic_hook = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,6 +1,13 @@
+use serde::Serialize;
 use shakmaty::fen::Fen;
-use shakmaty::{CastlingMode, Chess, EnPassantMode, Position};
+use shakmaty::{CastlingMode, Chess, Color, EnPassantMode, Position, Role};
+use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+}
 
 #[wasm_bindgen]
 pub fn greet() -> String {
@@ -34,15 +41,6 @@ pub fn fen_from_starting_position() -> String {
     Fen::default().to_string()
 }
 
-#[wasm_bindgen]
-pub fn fen_is_valid(fen: &str) -> bool {
-    let parsed: Result<Fen, _> = fen.parse();
-    match parsed {
-        Ok(f) => f.into_position::<Chess>(CastlingMode::Standard).is_ok(),
-        Err(_) => false,
-    }
-}
-
 pub(crate) fn fen_roundtrip_inner(fen: &str) -> Result<String, String> {
     let parsed: Fen = fen
         .parse()
@@ -66,10 +64,42 @@ pub fn fen_roundtrip(fen: &str) -> Result<String, JsValue> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GameStatus {
     InProgress = 0,
-    Check = 1,
-    Checkmate = 2,
-    Stalemate = 3,
-    Draw = 4,
+    Checkmate = 1,
+    Stalemate = 2,
+    Draw = 3,
+}
+
+fn piece_char(color: Color, role: Role) -> String {
+    let c = match role {
+        Role::Pawn => 'p',
+        Role::Knight => 'n',
+        Role::Bishop => 'b',
+        Role::Rook => 'r',
+        Role::Queen => 'q',
+        Role::King => 'k',
+    };
+    if color == Color::White {
+        c.to_ascii_uppercase().to_string()
+    } else {
+        c.to_string()
+    }
+}
+
+#[derive(Serialize)]
+struct RenderStateData {
+    fen: String,
+    board: HashMap<String, String>,
+    #[serde(rename = "legalMoves")]
+    legal_moves: Vec<String>,
+    status: u8,
+    #[serde(rename = "isCheck")]
+    is_check: bool,
+    #[serde(rename = "canUndo")]
+    can_undo: bool,
+    #[serde(rename = "canRedo")]
+    can_redo: bool,
+    #[serde(rename = "currentTurn")]
+    current_turn: String,
 }
 
 #[wasm_bindgen]
@@ -101,6 +131,10 @@ impl ChessGame {
         self.redo_stack.clear();
         Ok(())
     }
+
+    fn current_pos(&self) -> &Chess {
+        self.history.last().expect("history must never be empty")
+    }
 }
 
 #[wasm_bindgen]
@@ -114,8 +148,7 @@ impl ChessGame {
     }
 
     pub fn current_fen(&self) -> String {
-        let pos = self.history.last().expect("history must never be empty");
-        Fen::from_position(pos.clone(), EnPassantMode::Legal).to_string()
+        Fen::from_position(self.current_pos().clone(), EnPassantMode::Legal).to_string()
     }
 
     pub fn apply_move(&mut self, uci_move: &str) -> Result<(), JsValue> {
@@ -143,15 +176,13 @@ impl ChessGame {
     }
 
     pub fn game_status(&self) -> GameStatus {
-        let pos = self.history.last().expect("history must never be empty");
+        let pos = self.current_pos();
         if pos.is_checkmate() {
             GameStatus::Checkmate
         } else if pos.is_stalemate() {
             GameStatus::Stalemate
         } else if pos.is_insufficient_material() {
             GameStatus::Draw
-        } else if pos.is_check() {
-            GameStatus::Check
         } else {
             GameStatus::InProgress
         }
@@ -163,6 +194,43 @@ impl ChessGame {
 
     pub fn can_redo(&self) -> bool {
         !self.redo_stack.is_empty()
+    }
+
+    pub fn render_state(&self) -> Result<JsValue, JsValue> {
+        let pos = self.current_pos();
+        let fen = Fen::from_position(pos.clone(), EnPassantMode::Legal).to_string();
+
+        let board: HashMap<String, String> = pos
+            .board()
+            .clone()
+            .into_iter()
+            .map(|(sq, piece)| {
+                let sq_str = sq.to_string();
+                let piece_str = piece_char(piece.color, piece.role);
+                (sq_str, piece_str)
+            })
+            .collect();
+
+        let legal_moves = get_legal_moves_core(&fen).unwrap_or_default();
+
+        let current_turn = if pos.turn() == Color::White {
+            "white".to_string()
+        } else {
+            "black".to_string()
+        };
+
+        let data = RenderStateData {
+            fen,
+            board,
+            legal_moves,
+            status: self.game_status() as u8,
+            is_check: pos.is_check(),
+            can_undo: self.can_undo(),
+            can_redo: self.can_redo(),
+            current_turn,
+        };
+
+        serde_wasm_bindgen::to_value(&data).map_err(|e| JsValue::from_str(&e.to_string()))
     }
 }
 
@@ -242,22 +310,6 @@ mod tests {
             fen_from_starting_position(),
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
         );
-    }
-
-    #[test]
-    fn test_fen_valid() {
-        assert!(fen_is_valid(
-            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-        ));
-        assert!(fen_is_valid(
-            "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
-        ));
-    }
-
-    #[test]
-    fn test_fen_invalid() {
-        assert!(!fen_is_valid("not a fen string"));
-        assert!(!fen_is_valid(""));
     }
 
     #[test]
@@ -437,16 +489,29 @@ mod tests {
     }
 
     #[test]
-    fn game_status_check() {
+    fn check_position_game_status_is_in_progress() {
+        // In check, game is still InProgress (not a terminal state)
         let fen: Fen = "4k3/8/8/8/8/8/8/4RK2 b - - 0 1".parse().unwrap();
         let pos: Chess = fen
             .into_position(shakmaty::CastlingMode::Standard)
             .unwrap();
+        assert!(pos.is_check(), "position should be in check");
         let game = ChessGame {
             history: vec![pos],
             redo_stack: Vec::new(),
         };
-        assert_eq!(game.game_status(), GameStatus::Check);
+        // game_status() returns InProgress for check (not a separate Check state)
+        assert_eq!(game.game_status(), GameStatus::InProgress);
+    }
+
+    #[test]
+    fn is_check_detected_via_position() {
+        let fen: Fen = "4k3/8/8/8/8/8/8/4RK2 b - - 0 1".parse().unwrap();
+        let pos: Chess = fen
+            .into_position(shakmaty::CastlingMode::Standard)
+            .unwrap();
+        // pos.is_check() should return true for this check position
+        assert!(pos.is_check());
     }
 
     #[test]

--- a/wasm/tests/fen_tests.rs
+++ b/wasm/tests/fen_tests.rs
@@ -2,7 +2,7 @@ use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-use chess_wasm::{fen_from_starting_position, fen_is_valid, fen_roundtrip};
+use chess_wasm::{fen_from_starting_position, fen_roundtrip};
 
 #[wasm_bindgen_test]
 fn wasm_fen_from_starting_position() {
@@ -10,18 +10,6 @@ fn wasm_fen_from_starting_position() {
         fen_from_starting_position(),
         "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
     );
-}
-
-#[wasm_bindgen_test]
-fn wasm_fen_is_valid_true() {
-    assert!(fen_is_valid(
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-    ));
-}
-
-#[wasm_bindgen_test]
-fn wasm_fen_is_valid_false() {
-    assert!(!fen_is_valid("not a fen"));
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
Closes #43

## Changes
- `GameStatus` を5値→4値に変更 (`Check` 削除、discriminant: InProgress=0, Checkmate=1, Stalemate=2, Draw=3)
- `fen_is_valid()` 削除 (YAGNI)
- `render_state()` 追加: `board`, `isCheck`, `currentTurn` を含む JsValue を返す
- `console_error_panic_hook::set_once()` を `#[wasm_bindgen(start)]` で設定
- TypeScript `RenderState` に `board`, `isCheck`, `currentTurn` を追加
- Worker を `game.render_state()` 使用に変更

## Test
- cargo test: PASS (36 tests)
- bun run test: PASS (55 tests)
- bun run build: PASS