### PR TITLE
bolt-05: Remove dead READY from WorkerResponse + fix vite worker config

### DIFF
--- a/src/hooks/__tests__/useChessWorker.test.ts
+++ b/src/hooks/__tests__/useChessWorker.test.ts
@@ -27,6 +27,24 @@ vi.mock("../../worker/chess.worker?worker", () => {
   };
 });
 
+const INIT_STATE_UPDATE: WorkerResponse = {
+  type: "STATE_UPDATE",
+  payload: {
+    fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    board: {},
+    legalMoves: [],
+    status: 0,
+    isCheck: false,
+    canUndo: false,
+    canRedo: false,
+    currentTurn: "white",
+  },
+};
+
+function sendStateUpdate(payload = INIT_STATE_UPDATE) {
+  workerInstance.onmessage?.(new MessageEvent("message", { data: payload }));
+}
+
 describe("useChessWorker", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,13 +68,11 @@ describe("useChessWorker", () => {
     expect(workerInstance.postMessage).toHaveBeenCalledWith({ type: "INIT" });
   });
 
-  it("transitions to ready on READY message", () => {
+  it("transitions to ready on first STATE_UPDATE (INIT response)", () => {
     const { result } = renderHook(() => useChessWorker());
 
     act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
+      sendStateUpdate(INIT_STATE_UPDATE);
     });
 
     expect(result.current.initState).toBe("ready");
@@ -80,10 +96,9 @@ describe("useChessWorker", () => {
   it("stores lastError on post-init ERROR without changing initState", () => {
     const { result } = renderHook(() => useChessWorker());
 
+    // Become ready via STATE_UPDATE
     act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
+      sendStateUpdate(INIT_STATE_UPDATE);
     });
 
     act(() => {
@@ -101,13 +116,6 @@ describe("useChessWorker", () => {
   it("updates renderState on STATE_UPDATE message", () => {
     const { result } = renderHook(() => useChessWorker());
 
-    // First become ready
-    act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
-    });
-
     act(() => {
       workerInstance.onmessage?.(
         new MessageEvent("message", {
@@ -115,10 +123,13 @@ describe("useChessWorker", () => {
             type: "STATE_UPDATE",
             payload: {
               fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+              board: {},
               legalMoves: ["e2e4"],
               status: 0,
+              isCheck: false,
               canUndo: false,
               canRedo: false,
+              currentTurn: "white" as const,
             },
           },
         })
@@ -127,21 +138,21 @@ describe("useChessWorker", () => {
 
     expect(result.current.renderState).toEqual({
       fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      board: {},
       legalMoves: ["e2e4"],
       status: 0,
+      isCheck: false,
       canUndo: false,
       canRedo: false,
+      currentTurn: "white",
     });
+    expect(result.current.initState).toBe("ready");
   });
 
   it("sendMove posts APPLY_MOVE to worker", () => {
     const { result } = renderHook(() => useChessWorker());
 
-    act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
-    });
+    act(() => { sendStateUpdate(); });
 
     act(() => {
       result.current.sendMove("e2e4");
@@ -156,11 +167,7 @@ describe("useChessWorker", () => {
   it("sendUndo posts UNDO to worker", () => {
     const { result } = renderHook(() => useChessWorker());
 
-    act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
-    });
+    act(() => { sendStateUpdate(); });
 
     act(() => {
       result.current.sendUndo();
@@ -172,11 +179,7 @@ describe("useChessWorker", () => {
   it("sendRedo posts REDO to worker", () => {
     const { result } = renderHook(() => useChessWorker());
 
-    act(() => {
-      workerInstance.onmessage?.(
-        new MessageEvent("message", { data: { type: "READY" } })
-      );
-    });
+    act(() => { sendStateUpdate(); });
 
     act(() => {
       result.current.sendRedo();

--- a/src/hooks/useChessWorker.ts
+++ b/src/hooks/useChessWorker.ts
@@ -13,7 +13,6 @@ interface State {
 
 type Action =
   | { type: "START_INIT" }
-  | { type: "READY" }
   | { type: "ERROR"; message: string }
   | { type: "STATE_UPDATE"; payload: RenderState };
 
@@ -22,9 +21,6 @@ function reducer(state: State, action: Action): State {
     case "START_INIT":
       if (state.initState !== "uninit") return state;
       return { ...state, initState: "initializing" };
-    case "READY":
-      if (state.initState !== "initializing") return state;
-      return { ...state, initState: "ready" };
     case "ERROR":
       if (state.initState === "initializing") {
         return { ...state, initState: "error", lastError: action.message };
@@ -67,9 +63,6 @@ export function useChessWorker(): UseChessWorkerReturn {
     worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
       const msg = event.data;
       switch (msg.type) {
-        case "READY":
-          dispatch({ type: "READY" });
-          break;
         case "STATE_UPDATE":
           dispatch({ type: "STATE_UPDATE", payload: msg.payload });
           break;

--- a/src/worker/__tests__/types.test.ts
+++ b/src/worker/__tests__/types.test.ts
@@ -31,20 +31,18 @@ describe("WorkerRequest discriminated union", () => {
 });
 
 describe("WorkerResponse discriminated union", () => {
-  it("allows READY response", () => {
-    const resp: WorkerResponse = { type: "READY" };
-    expect(resp.type).toBe("READY");
-  });
-
   it("allows STATE_UPDATE response with RenderState payload", () => {
     const resp: WorkerResponse = {
       type: "STATE_UPDATE",
       payload: {
         fen: "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+        board: {},
         legalMoves: ["e7e5"],
         status: GameStatus.InProgress,
+        isCheck: false,
         canUndo: true,
         canRedo: false,
+        currentTurn: "black" as const,
       },
     };
     expect(resp.type).toBe("STATE_UPDATE");

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -7,6 +7,5 @@ export type WorkerRequest =
   | { type: "REDO" };
 
 export type WorkerResponse =
-  | { type: "READY" }
   | { type: "STATE_UPDATE"; payload: RenderState }
   | { type: "ERROR"; payload: { message: string } };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   plugins: [react(), wasm()],
   worker: {
     format: "es",
+    plugins: () => [wasm()],
   },
   build: {
     target: "esnext",


### PR DESCRIPTION
## Changes

- `worker/types.ts`: remove unused `READY` from `WorkerResponse` (worker never emits it; INIT returns `STATE_UPDATE` directly)
- `hooks/useChessWorker.ts`: remove dead `READY` action and handler from reducer
- `hooks/__tests__/useChessWorker.test.ts`: update tests to use `STATE_UPDATE` for init (no READY)
- `worker/__tests__/types.test.ts`: remove obsolete READY type test
- `vite.config.ts`: add `plugins: () => [wasm()]` to worker config for WASM in workers

## Context

Closes #5