### PR TITLE
feat: WASM reset() API + Worker RESET メッセージ (bolt-16)

### DIFF
--- a/src/worker/__tests__/reset.test.ts
+++ b/src/worker/__tests__/reset.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { WorkerRequest, WorkerResponse } from "../types";
+import { GameStatus } from "../../types/chess";
+
+const STARTING_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+const AFTER_E2E4_FEN = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+
+class MockChessGame {
+  private fen = STARTING_FEN;
+
+  current_fen() { return this.fen; }
+  game_status() { return GameStatus.InProgress; }
+  can_undo() { return this.fen !== STARTING_FEN; }
+  can_redo() { return false; }
+
+  apply_move(uciMove: string) {
+    if (uciMove === "e2e4") this.fen = AFTER_E2E4_FEN;
+    else throw new Error(`Illegal move: ${uciMove}`);
+  }
+  undo() { this.fen = STARTING_FEN; }
+  redo() {}
+  reset() { this.fen = STARTING_FEN; }
+  render_state() {
+    return {
+      fen: this.fen,
+      board: {},
+      legalMoves: [],
+      status: GameStatus.InProgress,
+      isCheck: false,
+      canUndo: this.can_undo(),
+      canRedo: this.can_redo(),
+      currentTurn: "white" as const,
+    };
+  }
+}
+
+const mockInitFn = vi.fn().mockResolvedValue(undefined);
+let mockGameInstance: MockChessGame;
+
+vi.mock("../../../wasm-pkg/chess_wasm", () => ({
+  default: mockInitFn,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ChessGame: function (this: any) { return mockGameInstance; },
+}));
+
+const mockPostMessage = vi.fn();
+vi.stubGlobal("postMessage", mockPostMessage);
+
+const mockLocalStorage = {
+  removeItem: vi.fn(),
+};
+vi.stubGlobal("localStorage", mockLocalStorage);
+
+let handleMessage: (event: MessageEvent<WorkerRequest>) => Promise<void>;
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockPostMessage.mockClear();
+  mockLocalStorage.removeItem.mockClear();
+  mockInitFn.mockClear().mockResolvedValue(undefined);
+  mockGameInstance = new MockChessGame();
+  const mod = await import("../chess.worker");
+  handleMessage = mod.handleMessage;
+});
+
+describe("RESET message", () => {
+  it("responds STATE_UPDATE with initial position after RESET", async () => {
+    await handleMessage(new MessageEvent("message", { data: { type: "INIT" } }));
+    await handleMessage(new MessageEvent("message", {
+      data: { type: "APPLY_MOVE", payload: { uciMove: "e2e4" } },
+    }));
+    mockPostMessage.mockClear();
+
+    await handleMessage(new MessageEvent("message", { data: { type: "RESET" } }));
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "STATE_UPDATE",
+        payload: expect.objectContaining({ fen: STARTING_FEN }),
+      })
+    );
+  });
+
+  it("clears localStorage on RESET", async () => {
+    await handleMessage(new MessageEvent("message", { data: { type: "INIT" } }));
+    await handleMessage(new MessageEvent("message", { data: { type: "RESET" } }));
+
+    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith("chess_events");
+    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith("chess_snapshot");
+  });
+
+  it("returns ERROR if RESET called before INIT", async () => {
+    await handleMessage(new MessageEvent("message", { data: { type: "RESET" } }));
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "ERROR" })
+    );
+  });
+});

--- a/src/worker/chess.worker.ts
+++ b/src/worker/chess.worker.ts
@@ -74,6 +74,21 @@ export async function handleMessage(
       }
       break;
     }
+    case "RESET": {
+      try {
+        if (!game) throw new Error("Game not initialized");
+        game.reset();
+        localStorage.removeItem("chess_events");
+        localStorage.removeItem("chess_snapshot");
+        postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
+      } catch (e) {
+        postResponse({
+          type: "ERROR",
+          payload: { message: String(e) },
+        });
+      }
+      break;
+    }
   }
 }
 

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -4,7 +4,8 @@ export type WorkerRequest =
   | { type: "INIT" }
   | { type: "APPLY_MOVE"; payload: { uciMove: string } }
   | { type: "UNDO" }
-  | { type: "REDO" };
+  | { type: "REDO" }
+  | { type: "RESET" };
 
 export type WorkerResponse =
   | { type: "READY" }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -196,6 +196,11 @@ impl ChessGame {
         !self.redo_stack.is_empty()
     }
 
+    pub fn reset(&mut self) {
+        self.history = vec![Chess::default()];
+        self.redo_stack.clear();
+    }
+
     pub fn render_state(&self) -> Result<JsValue, JsValue> {
         let pos = self.current_pos();
         let fen = Fen::from_position(pos.clone(), EnPassantMode::Legal).to_string();
@@ -545,5 +550,46 @@ mod tests {
         apply(&mut game, "e2e4");
         game.undo();
         assert!(game.can_redo());
+    }
+
+    #[test]
+    fn reset_returns_to_starting_position() {
+        let mut game = ChessGame::new();
+        apply(&mut game, "e2e4");
+        apply(&mut game, "e7e5");
+        game.reset();
+        assert_eq!(
+            game.current_fen(),
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        );
+    }
+
+    #[test]
+    fn reset_clears_undo_history() {
+        let mut game = ChessGame::new();
+        apply(&mut game, "e2e4");
+        assert!(game.can_undo());
+        game.reset();
+        assert!(!game.can_undo());
+    }
+
+    #[test]
+    fn reset_clears_redo_stack() {
+        let mut game = ChessGame::new();
+        apply(&mut game, "e2e4");
+        game.undo();
+        assert!(game.can_redo());
+        game.reset();
+        assert!(!game.can_redo());
+    }
+
+    #[test]
+    fn reset_on_fresh_game_is_idempotent() {
+        let mut game = ChessGame::new();
+        game.reset();
+        assert_eq!(
+            game.current_fen(),
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        );
     }
 }


### PR DESCRIPTION
Closes #31

## Changes
- `ChessGame::reset()`: 初期局面に戻し history/redo_stack をクリア
- `WorkerRequest` に `RESET` を追加
- Worker の `RESET` ハンドラ: `game.reset()` + localStorage クリア + `STATE_UPDATE` 返却

## Test
- cargo test: PASS (40 tests)
- bun run test: PASS (58 tests)
- bun run build: PASS