### PR TITLE
feat: localStorage event sourcing (bolt-08)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { WasmErrorBoundary } from "./components/WasmErrorBoundary";
 import { Board } from "./components/Board";
 import { GameStatus } from "./components/GameStatus";
 import { FlipButton } from "./components/FlipButton";
+import { ResetButton } from "./components/ResetButton";
 import { getFenTurn } from "./utils/fen";
 
 function LoadingIndicator() {
@@ -27,7 +28,7 @@ function ErrorMessage({ message }: { message: string }) {
 }
 
 function ChessApp() {
-  const { initState, renderState, sendMove, sendUndo, sendRedo } =
+  const { initState, renderState, sendMove, sendUndo, sendRedo, resetGame } =
     useChessWorker();
   const [flipped, setFlipped] = useState(false);
 
@@ -76,6 +77,7 @@ function ChessApp() {
             >
               Redo
             </button>
+            <ResetButton onClick={resetGame} />
           </div>
         </div>
       );

--- a/src/components/GameStatus.tsx
+++ b/src/components/GameStatus.tsx
@@ -16,7 +16,6 @@ export function GameStatus({ status, currentTurn }: GameStatusProps) {
 
   const messages: Record<GameStatusEnum, string> = {
     [GameStatusEnum.InProgress]: "",
-    [GameStatusEnum.Check]: `${currentTurn === "white" ? "White" : "Black"} is in check`,
     [GameStatusEnum.Checkmate]: `Checkmate — ${currentTurn === "white" ? "Black" : "White"} wins!`,
     [GameStatusEnum.Stalemate]: "Stalemate — Draw!",
     [GameStatusEnum.Draw]: "Draw!",

--- a/src/components/ResetButton.tsx
+++ b/src/components/ResetButton.tsx
@@ -1,0 +1,18 @@
+export function ResetButton({ onClick }: { onClick: () => void }) {
+  const handleClick = () => {
+    if (window.confirm("Start a new game? Current game will be lost.")) {
+      onClick();
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      type="button"
+      aria-label="Start a new game (current game will be lost)"
+      style={{ marginLeft: "8px" }}
+    >
+      New Game
+    </button>
+  );
+}

--- a/src/hooks/__tests__/useBoardInteraction.test.ts
+++ b/src/hooks/__tests__/useBoardInteraction.test.ts
@@ -9,10 +9,13 @@ const START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 function makeRenderState(overrides?: Partial<RenderState>): RenderState {
   return {
     fen: START_FEN,
+    board: {},
     legalMoves: ["e2e4", "e2e3", "d2d4", "d2d3", "a2a3", "a2a4"],
     status: GameStatus.InProgress,
+    isCheck: false,
     canUndo: false,
     canRedo: false,
+    currentTurn: "white" as const,
     ...overrides,
   };
 }

--- a/src/hooks/__tests__/useChessWorker.test.ts
+++ b/src/hooks/__tests__/useChessWorker.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useChessWorker } from "../useChessWorker";
 import type { WorkerResponse } from "../../worker/types";
+import * as storage from "../../utils/storage";
 
 // Mock the Worker class
 let workerInstance: {
@@ -192,5 +193,64 @@ describe("useChessWorker", () => {
     const { unmount } = renderHook(() => useChessWorker());
     unmount();
     expect(workerInstance.terminate).toHaveBeenCalled();
+  });
+
+  describe("localStorage event sourcing", () => {
+    it("sends INIT_FROM_EVENTS when localStorage has saved moves", () => {
+      vi.spyOn(storage, "loadMoveEvents").mockReturnValue(["e2e4", "e7e5"]);
+      renderHook(() => useChessWorker());
+      expect(workerInstance.postMessage).toHaveBeenCalledWith({
+        type: "INIT_FROM_EVENTS",
+        payload: { uciMoves: ["e2e4", "e7e5"] },
+      });
+    });
+
+    it("sends INIT when localStorage is empty", () => {
+      vi.spyOn(storage, "loadMoveEvents").mockReturnValue([]);
+      renderHook(() => useChessWorker());
+      expect(workerInstance.postMessage).toHaveBeenCalledWith({ type: "INIT" });
+    });
+
+    it("sendMove calls saveMoveEvent", () => {
+      const spy = vi.spyOn(storage, "saveMoveEvent").mockImplementation(() => {});
+      const { result } = renderHook(() => useChessWorker());
+
+      act(() => { sendStateUpdate(); });
+
+      act(() => {
+        result.current.sendMove("e2e4");
+      });
+
+      expect(spy).toHaveBeenCalledWith("e2e4");
+    });
+
+    it("resetGame clears localStorage and sends INIT", () => {
+      const clearSpy = vi.spyOn(storage, "clearMoveEvents").mockImplementation(() => {});
+      const { result } = renderHook(() => useChessWorker());
+
+      act(() => { sendStateUpdate(); });
+
+      workerInstance.postMessage.mockClear();
+
+      act(() => {
+        result.current.resetGame();
+      });
+
+      expect(clearSpy).toHaveBeenCalled();
+      expect(workerInstance.postMessage).toHaveBeenCalledWith({ type: "INIT" });
+    });
+
+    it("resetGame sets initState back to initializing", () => {
+      const { result } = renderHook(() => useChessWorker());
+
+      act(() => { sendStateUpdate(); });
+      expect(result.current.initState).toBe("ready");
+
+      act(() => {
+        result.current.resetGame();
+      });
+
+      expect(result.current.initState).toBe("initializing");
+    });
   });
 });

--- a/src/hooks/useChessWorker.ts
+++ b/src/hooks/useChessWorker.ts
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useReducer, useRef } from "react";
 import type { RenderState } from "../types/chess";
 import type { WorkerResponse } from "../worker/types";
 import ChessWorker from "../worker/chess.worker?worker";
+import {
+  saveMoveEvent,
+  loadMoveEvents,
+  clearMoveEvents,
+} from "../utils/storage";
 
 export type InitState = "uninit" | "initializing" | "ready" | "error";
 
@@ -13,19 +18,27 @@ interface State {
 
 type Action =
   | { type: "START_INIT" }
+  | { type: "RESET" }
   | { type: "ERROR"; message: string }
   | { type: "STATE_UPDATE"; payload: RenderState };
+
+const initialState: State = {
+  initState: "uninit",
+  renderState: null,
+  lastError: null,
+};
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "START_INIT":
       if (state.initState !== "uninit") return state;
       return { ...state, initState: "initializing" };
+    case "RESET":
+      return { ...initialState, initState: "initializing" };
     case "ERROR":
       if (state.initState === "initializing") {
         return { ...state, initState: "error", lastError: action.message };
       }
-      // Post-init errors (APPLY_MOVE, UNDO, REDO): store message without state change
       return { ...state, lastError: action.message };
     case "STATE_UPDATE":
       if (state.initState === "initializing") {
@@ -37,12 +50,6 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-const initialState: State = {
-  initState: "uninit",
-  renderState: null,
-  lastError: null,
-};
-
 export interface UseChessWorkerReturn {
   initState: InitState;
   renderState: RenderState | null;
@@ -50,6 +57,7 @@ export interface UseChessWorkerReturn {
   sendMove: (uciMove: string) => void;
   sendUndo: () => void;
   sendRedo: () => void;
+  resetGame: () => void;
 }
 
 export function useChessWorker(): UseChessWorkerReturn {
@@ -73,7 +81,16 @@ export function useChessWorker(): UseChessWorkerReturn {
     };
 
     dispatch({ type: "START_INIT" });
-    worker.postMessage({ type: "INIT" });
+
+    const savedMoves = loadMoveEvents();
+    if (savedMoves.length > 0) {
+      worker.postMessage({
+        type: "INIT_FROM_EVENTS",
+        payload: { uciMoves: savedMoves },
+      });
+    } else {
+      worker.postMessage({ type: "INIT" });
+    }
 
     return () => {
       worker.terminate();
@@ -82,6 +99,7 @@ export function useChessWorker(): UseChessWorkerReturn {
   }, []);
 
   const sendMove = useCallback((uciMove: string) => {
+    saveMoveEvent(uciMove);
     workerRef.current?.postMessage({
       type: "APPLY_MOVE",
       payload: { uciMove },
@@ -96,6 +114,12 @@ export function useChessWorker(): UseChessWorkerReturn {
     workerRef.current?.postMessage({ type: "REDO" });
   }, []);
 
+  const resetGame = useCallback(() => {
+    clearMoveEvents();
+    dispatch({ type: "RESET" });
+    workerRef.current?.postMessage({ type: "INIT" });
+  }, []);
+
   return {
     initState: state.initState,
     renderState: state.renderState,
@@ -103,5 +127,6 @@ export function useChessWorker(): UseChessWorkerReturn {
     sendMove,
     sendUndo,
     sendRedo,
+    resetGame,
   };
 }

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { saveMoveEvent, loadMoveEvents, clearMoveEvents } from "../storage";
+
+const STORAGE_KEY = "chess_move_events";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("loadMoveEvents", () => {
+  it("returns empty array when no data", () => {
+    expect(loadMoveEvents()).toEqual([]);
+  });
+
+  it("returns empty array on invalid JSON", () => {
+    localStorage.setItem(STORAGE_KEY, "not json");
+    expect(loadMoveEvents()).toEqual([]);
+  });
+
+  it("returns empty array on non-array JSON", () => {
+    localStorage.setItem(STORAGE_KEY, '{"a":1}');
+    expect(loadMoveEvents()).toEqual([]);
+  });
+
+  it("returns saved moves", () => {
+    localStorage.setItem(STORAGE_KEY, '["e2e4","e7e5"]');
+    expect(loadMoveEvents()).toEqual(["e2e4", "e7e5"]);
+  });
+});
+
+describe("saveMoveEvent", () => {
+  it("creates new array with single move", () => {
+    saveMoveEvent("e2e4");
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(["e2e4"]);
+  });
+
+  it("appends to existing moves", () => {
+    localStorage.setItem(STORAGE_KEY, '["e2e4"]');
+    saveMoveEvent("e7e5");
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(["e2e4", "e7e5"]);
+  });
+
+  it("does not overwrite on corrupt JSON", () => {
+    localStorage.setItem(STORAGE_KEY, "corrupt");
+    saveMoveEvent("e2e4");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("corrupt");
+  });
+});
+
+describe("clearMoveEvents", () => {
+  it("removes the storage key", () => {
+    localStorage.setItem(STORAGE_KEY, '["e2e4"]');
+    clearMoveEvents();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,29 @@
+const STORAGE_KEY = "chess_move_events";
+
+export function saveMoveEvent(uciMove: string): void {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const events = raw ? JSON.parse(raw) : [];
+    if (!Array.isArray(events)) return;
+    events.push(uciMove);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+  } catch {
+    // Corrupt storage — don't overwrite, just skip
+  }
+}
+
+export function loadMoveEvents(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+export function clearMoveEvents(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/worker/__tests__/chess.worker.test.ts
+++ b/src/worker/__tests__/chess.worker.test.ts
@@ -191,4 +191,32 @@ describe("chess.worker message routing", () => {
       })
     );
   });
+
+  it("responds STATE_UPDATE to INIT_FROM_EVENTS with replayed moves", async () => {
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "INIT_FROM_EVENTS", payload: { uciMoves: ["e2e4"] } },
+      })
+    );
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "STATE_UPDATE",
+        payload: expect.objectContaining({
+          fen: AFTER_E2E4_FEN,
+          canUndo: true,
+        }),
+      })
+    );
+  });
+
+  it("responds ERROR to INIT_FROM_EVENTS with invalid move", async () => {
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "INIT_FROM_EVENTS", payload: { uciMoves: ["e2e4", "e2e9"] } },
+      })
+    );
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "ERROR" })
+    );
+  });
 });

--- a/src/worker/__tests__/reset.test.ts
+++ b/src/worker/__tests__/reset.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { WorkerRequest, WorkerResponse } from "../types";
+import type { WorkerRequest } from "../types";
 import { GameStatus } from "../../types/chess";
 
 const STARTING_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
@@ -19,7 +19,6 @@ class MockChessGame {
   }
   undo() { this.fen = STARTING_FEN; }
   redo() {}
-  reset() { this.fen = STARTING_FEN; }
   render_state() {
     return {
       fen: this.fen,
@@ -39,24 +38,22 @@ let mockGameInstance: MockChessGame;
 
 vi.mock("../../../wasm-pkg/chess_wasm", () => ({
   default: mockInitFn,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ChessGame: function (this: any) { return mockGameInstance; },
+  ChessGame: class {
+    constructor() {
+      mockGameInstance = new MockChessGame();
+      return mockGameInstance;
+    }
+  },
 }));
 
 const mockPostMessage = vi.fn();
 vi.stubGlobal("postMessage", mockPostMessage);
-
-const mockLocalStorage = {
-  removeItem: vi.fn(),
-};
-vi.stubGlobal("localStorage", mockLocalStorage);
 
 let handleMessage: (event: MessageEvent<WorkerRequest>) => Promise<void>;
 
 beforeEach(async () => {
   vi.resetModules();
   mockPostMessage.mockClear();
-  mockLocalStorage.removeItem.mockClear();
   mockInitFn.mockClear().mockResolvedValue(undefined);
   mockGameInstance = new MockChessGame();
   const mod = await import("../chess.worker");
@@ -81,19 +78,14 @@ describe("RESET message", () => {
     );
   });
 
-  it("clears localStorage on RESET", async () => {
-    await handleMessage(new MessageEvent("message", { data: { type: "INIT" } }));
-    await handleMessage(new MessageEvent("message", { data: { type: "RESET" } }));
-
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith("chess_events");
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith("chess_snapshot");
-  });
-
-  it("returns ERROR if RESET called before INIT", async () => {
+  it("RESET works even without prior INIT (re-initializes WASM)", async () => {
     await handleMessage(new MessageEvent("message", { data: { type: "RESET" } }));
 
     expect(mockPostMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "ERROR" })
+      expect.objectContaining({
+        type: "STATE_UPDATE",
+        payload: expect.objectContaining({ fen: STARTING_FEN }),
+      })
     );
   });
 });

--- a/src/worker/chess.worker.ts
+++ b/src/worker/chess.worker.ts
@@ -35,6 +35,23 @@ export async function handleMessage(
       }
       break;
     }
+    case "INIT_FROM_EVENTS": {
+      try {
+        const mod = await import("../../wasm-pkg/chess_wasm");
+        await mod.default();
+        game = new mod.ChessGame();
+        for (const move of data.payload.uciMoves) {
+          game.apply_move(move);
+        }
+        postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
+      } catch (e) {
+        postResponse({
+          type: "ERROR",
+          payload: { message: String(e) },
+        });
+      }
+      break;
+    }
     case "APPLY_MOVE": {
       try {
         if (!game) throw new Error("Game not initialized");
@@ -76,10 +93,9 @@ export async function handleMessage(
     }
     case "RESET": {
       try {
-        if (!game) throw new Error("Game not initialized");
-        game.reset();
-        localStorage.removeItem("chess_events");
-        localStorage.removeItem("chess_snapshot");
+        const mod = await import("../../wasm-pkg/chess_wasm");
+        await mod.default();
+        game = new mod.ChessGame();
         postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -2,6 +2,7 @@ import type { RenderState } from "../types/chess";
 
 export type WorkerRequest =
   | { type: "INIT" }
+  | { type: "INIT_FROM_EVENTS"; payload: { uciMoves: string[] } }
   | { type: "APPLY_MOVE"; payload: { uciMove: string } }
   | { type: "UNDO" }
   | { type: "REDO" }


### PR DESCRIPTION
Closes #8

## Changes
- localStorage utils: save/load/clear move events
- INIT_FROM_EVENTS worker message to replay saved moves on reload
- useChessWorker persists moves to localStorage, restores on mount
- RESET action in reducer for proper state reset during resetGame
- ResetButton with confirmation dialog and ARIA label
- Fix pre-existing type issues (GameStatus.Check removal, RenderState shape, game.reset())

## Test
- `bun run test`: 71/71 pass
- `npx tsc --noEmit`: clean
- `bun run build`: success

🤖 Generated with [Claude Code](https://claude.com/claude-code)