### PR TITLE
feat: start screen + game phase state machine (bolt-18)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4",
@@ -286,6 +287,8 @@
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useChessWorker } from "./hooks/useChessWorker";
 import { WasmErrorBoundary } from "./components/WasmErrorBoundary";
+import { StartScreen } from "./components/StartScreen";
 import { Board } from "./components/Board";
 import { GameStatus } from "./components/GameStatus";
 import { FlipButton } from "./components/FlipButton";
 import { GameOverModal } from "./components/GameOverModal";
 import { ResetButton } from "./components/ResetButton";
 import { getFenTurn } from "./utils/fen";
+import { loadMoveEvents } from "./utils/storage";
+import type { GameMode, AppPhase } from "./types/game";
 
 function LoadingIndicator() {
   return (
@@ -28,7 +31,7 @@ function ErrorMessage({ message }: { message: string }) {
   );
 }
 
-function ChessApp() {
+function ChessApp({ gameMode: _gameMode }: { gameMode: GameMode | null }) {
   const { initState, renderState, sendMove, sendUndo, sendRedo, resetGame } =
     useChessWorker();
   const [flipped, setFlipped] = useState(false);
@@ -91,13 +94,35 @@ function ChessApp() {
 }
 
 export function App() {
+  const [phase, setPhase] = useState<AppPhase>("mode-select");
+  const [gameMode, setGameMode] = useState<GameMode | null>(null);
+
+  // Skip mode-select if localStorage has saved moves
+  useEffect(() => {
+    const savedMoves = loadMoveEvents();
+    if (savedMoves.length > 0) {
+      setGameMode("human-vs-human");
+      setPhase("playing");
+    }
+  }, []);
+
+  const handleSelectMode = (mode: GameMode) => {
+    setGameMode(mode);
+    setPhase("playing");
+  };
+
+  if (phase === "mode-select") {
+    return <StartScreen onSelectMode={handleSelectMode} />;
+  }
+
+  // phase === "playing"
   return (
     <WasmErrorBoundary
       fallback={
         <ErrorMessage message="Something went wrong initializing the chess engine." />
       }
     >
-      <ChessApp />
+      <ChessApp gameMode={gameMode} />
     </WasmErrorBoundary>
   );
 }

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,0 +1,38 @@
+import type { GameMode } from "../types/game";
+
+interface StartScreenProps {
+  onSelectMode: (mode: GameMode) => void;
+}
+
+export function StartScreen({ onSelectMode }: StartScreenProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "24px",
+        padding: "48px 16px",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <h1>Chess</h1>
+      <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+        <button
+          type="button"
+          onClick={() => onSelectMode("human-vs-human")}
+          style={{ padding: "12px 24px", fontSize: "16px", cursor: "pointer" }}
+        >
+          Human vs Human
+        </button>
+        <button
+          type="button"
+          onClick={() => onSelectMode("human-vs-cpu")}
+          style={{ padding: "12px 24px", fontSize: "16px", cursor: "pointer" }}
+        >
+          Human vs Computer
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { App } from "../../App";
+
+// Mock the Worker
+vi.mock("../../worker/chess.worker?worker", () => {
+  const MockWorker = vi.fn(function (this: {
+    postMessage: ReturnType<typeof vi.fn>;
+    terminate: ReturnType<typeof vi.fn>;
+    onmessage: null;
+  }) {
+    this.postMessage = vi.fn();
+    this.terminate = vi.fn();
+    this.onmessage = null;
+  });
+  return { default: MockWorker };
+});
+
+// Mock storage module
+vi.mock("../../utils/storage", () => ({
+  loadMoveEvents: vi.fn(() => []),
+  saveMoveEvent: vi.fn(),
+  clearMoveEvents: vi.fn(),
+}));
+
+import { loadMoveEvents } from "../../utils/storage";
+
+beforeEach(() => {
+  vi.mocked(loadMoveEvents).mockReturnValue([]);
+});
+
+describe("App", () => {
+  it("renders StartScreen when no saved moves", () => {
+    render(<App />);
+
+    expect(screen.getByText("Chess")).toBeDefined();
+    expect(screen.getByText("Human vs Human")).toBeDefined();
+    expect(screen.getByText("Human vs Computer")).toBeDefined();
+  });
+
+  it("transitions to playing phase when a mode button is clicked", async () => {
+    render(<App />);
+
+    await userEvent.click(screen.getByText("Human vs Human"));
+
+    // StartScreen should be gone, loading indicator should appear
+    expect(screen.queryByText("Chess")).toBeNull();
+    expect(
+      screen.getByRole("status", { name: "Loading chess engine" })
+    ).toBeDefined();
+  });
+
+  it("skips start screen when localStorage has saved moves", () => {
+    vi.mocked(loadMoveEvents).mockReturnValue(["e2e4", "e7e5"]);
+
+    render(<App />);
+
+    // Should not show StartScreen
+    expect(screen.queryByText("Human vs Human")).toBeNull();
+    // Should show loading indicator (ChessApp initializing)
+    expect(
+      screen.getByRole("status", { name: "Loading chess engine" })
+    ).toBeDefined();
+  });
+});

--- a/src/components/__tests__/StartScreen.test.tsx
+++ b/src/components/__tests__/StartScreen.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StartScreen } from "../StartScreen";
+
+describe("StartScreen", () => {
+  it("renders title and two mode buttons", () => {
+    render(<StartScreen onSelectMode={vi.fn()} />);
+
+    expect(screen.getByText("Chess")).toBeDefined();
+    expect(screen.getByText("Human vs Human")).toBeDefined();
+    expect(screen.getByText("Human vs Computer")).toBeDefined();
+  });
+
+  it('calls onSelectMode with "human-vs-human" when clicking Human vs Human', async () => {
+    const onSelectMode = vi.fn();
+    render(<StartScreen onSelectMode={onSelectMode} />);
+
+    await userEvent.click(screen.getByText("Human vs Human"));
+
+    expect(onSelectMode).toHaveBeenCalledWith("human-vs-human");
+  });
+
+  it('calls onSelectMode with "human-vs-cpu" when clicking Human vs Computer', async () => {
+    const onSelectMode = vi.fn();
+    render(<StartScreen onSelectMode={onSelectMode} />);
+
+    await userEvent.click(screen.getByText("Human vs Computer"));
+
+    expect(onSelectMode).toHaveBeenCalledWith("human-vs-cpu");
+  });
+});

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,2 @@
+export type GameMode = "human-vs-human" | "human-vs-cpu";
+export type AppPhase = "mode-select" | "playing";


### PR DESCRIPTION
## Summary
- Add `StartScreen` component with "Human vs Human" and "Human vs Computer" mode selection buttons
- Introduce `AppPhase` / `GameMode` types and a phase state machine in `App.tsx` (`mode-select` -> `playing`)
- Auto-skip start screen when localStorage has saved moves (defaults to `human-vs-human`)
- `gameMode` prop passed to `ChessApp` (unused until bolt-12 adds CPU logic)

## Test plan
- [x] StartScreen renders title and two buttons
- [x] Clicking each button calls `onSelectMode` with correct mode string
- [x] App renders StartScreen when no saved moves
- [x] Clicking mode button transitions to playing phase (loading indicator)
- [x] Saved moves in localStorage skip start screen
- [x] `bun run build` succeeds
- [x] `npx tsc --noEmit` clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)