### PR TITLE
bolt: localStorage FEN スナップショット最適化 (#9)

### DIFF
--- a/src/hooks/useChessWorker.ts
+++ b/src/hooks/useChessWorker.ts
@@ -4,8 +4,10 @@ import type { WorkerResponse } from "../worker/types";
 import ChessWorker from "../worker/chess.worker?worker";
 import {
   saveMoveEvent,
-  loadMoveEvents,
+  saveSnapshot,
+  loadGameState,
   clearMoveEvents,
+  SNAPSHOT_INTERVAL,
 } from "../utils/storage";
 
 export type InitState = "uninit" | "initializing" | "ready" | "error";
@@ -64,6 +66,8 @@ export interface UseChessWorkerReturn {
 export function useChessWorker(): UseChessWorkerReturn {
   const [state, dispatch] = useReducer(reducer, initialState);
   const workerRef = useRef<InstanceType<typeof ChessWorker> | null>(null);
+  const moveCountRef = useRef(0);
+  const pendingSnapshotRef = useRef(false);
 
   useEffect(() => {
     const worker = new ChessWorker();
@@ -74,6 +78,10 @@ export function useChessWorker(): UseChessWorkerReturn {
       switch (msg.type) {
         case "STATE_UPDATE":
           dispatch({ type: "STATE_UPDATE", payload: msg.payload });
+          if (pendingSnapshotRef.current) {
+            saveSnapshot(msg.payload.fen);
+            pendingSnapshotRef.current = false;
+          }
           break;
         case "ERROR":
           dispatch({ type: "ERROR", message: msg.payload.message });
@@ -83,11 +91,12 @@ export function useChessWorker(): UseChessWorkerReturn {
 
     dispatch({ type: "START_INIT" });
 
-    const savedMoves = loadMoveEvents();
-    if (savedMoves.length > 0) {
+    const { fenSnapshot, uciMoves } = loadGameState();
+    if (fenSnapshot !== null || uciMoves.length > 0) {
+      moveCountRef.current = uciMoves.length;
       worker.postMessage({
         type: "INIT_FROM_EVENTS",
-        payload: { uciMoves: savedMoves },
+        payload: { fenSnapshot, uciMoves },
       });
     } else {
       worker.postMessage({ type: "INIT" });
@@ -101,6 +110,10 @@ export function useChessWorker(): UseChessWorkerReturn {
 
   const sendMove = useCallback((uciMove: string) => {
     saveMoveEvent(uciMove);
+    moveCountRef.current += 1;
+    if (moveCountRef.current % SNAPSHOT_INTERVAL === 0) {
+      pendingSnapshotRef.current = true;
+    }
     workerRef.current?.postMessage({
       type: "APPLY_MOVE",
       payload: { uciMove },
@@ -117,6 +130,8 @@ export function useChessWorker(): UseChessWorkerReturn {
 
   const resetGame = useCallback(() => {
     clearMoveEvents();
+    moveCountRef.current = 0;
+    pendingSnapshotRef.current = false;
     dispatch({ type: "RESET" });
     workerRef.current?.postMessage({ type: "INIT" });
   }, []);

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { saveMoveEvent, loadMoveEvents, clearMoveEvents } from "../storage";
+import {
+  saveMoveEvent,
+  loadMoveEvents,
+  clearMoveEvents,
+  saveSnapshot,
+  loadGameState,
+  SNAPSHOT_INTERVAL,
+} from "../storage";
 
 describe("storage", () => {
   beforeEach(() => {
@@ -49,6 +56,51 @@ describe("storage", () => {
       clearMoveEvents();
       expect(loadMoveEvents()).toEqual([]);
       expect(localStorage.getItem("chess_move_events")).toBeNull();
+    });
+
+    it("also clears the FEN snapshot", () => {
+      saveSnapshot("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1");
+      clearMoveEvents();
+      expect(localStorage.getItem("chess_fen_snapshot")).toBeNull();
+    });
+  });
+
+  describe("saveSnapshot", () => {
+    it("saves FEN to localStorage", () => {
+      const fen = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+      saveSnapshot(fen);
+      expect(localStorage.getItem("chess_fen_snapshot")).toBe(fen);
+    });
+
+    it("clears move events when saving snapshot", () => {
+      saveMoveEvent("e2e4");
+      saveMoveEvent("e7e5");
+      saveSnapshot("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1");
+      expect(loadMoveEvents()).toEqual([]);
+    });
+  });
+
+  describe("loadGameState", () => {
+    it("returns null fenSnapshot and empty uciMoves when nothing stored", () => {
+      expect(loadGameState()).toEqual({ fenSnapshot: null, uciMoves: [] });
+    });
+
+    it("returns stored fenSnapshot and uciMoves", () => {
+      const fen = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+      saveSnapshot(fen);
+      saveMoveEvent("e7e5");
+      expect(loadGameState()).toEqual({ fenSnapshot: fen, uciMoves: ["e7e5"] });
+    });
+
+    it("returns null fenSnapshot with moves when no snapshot", () => {
+      saveMoveEvent("e2e4");
+      expect(loadGameState()).toEqual({ fenSnapshot: null, uciMoves: ["e2e4"] });
+    });
+  });
+
+  describe("SNAPSHOT_INTERVAL", () => {
+    it("is 20", () => {
+      expect(SNAPSHOT_INTERVAL).toBe(20);
     });
   });
 });

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,4 +1,18 @@
 const STORAGE_KEY = "chess_move_events";
+const SNAPSHOT_KEY = "chess_fen_snapshot";
+export const SNAPSHOT_INTERVAL = 20;
+
+export function saveSnapshot(fen: string): void {
+  localStorage.setItem(SNAPSHOT_KEY, fen);
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function loadGameState(): { fenSnapshot: string | null; uciMoves: string[] } {
+  return {
+    fenSnapshot: localStorage.getItem(SNAPSHOT_KEY),
+    uciMoves: loadMoveEvents(),
+  };
+}
 
 export function saveMoveEvent(uciMove: string): void {
   try {
@@ -26,4 +40,5 @@ export function loadMoveEvents(): string[] {
 
 export function clearMoveEvents(): void {
   localStorage.removeItem(STORAGE_KEY);
+  localStorage.removeItem(SNAPSHOT_KEY);
 }

--- a/src/worker/__tests__/chess.worker.test.ts
+++ b/src/worker/__tests__/chess.worker.test.ts
@@ -10,9 +10,13 @@ const AFTER_E2E4_FEN =
 // --- Mock WASM module ---
 
 class MockChessGame {
-  private fen = STARTING_FEN;
+  private fen: string;
   private undoStack: string[] = [];
   private redoStack: string[] = [];
+
+  constructor(initialFen = STARTING_FEN) {
+    this.fen = initialFen;
+  }
 
   current_fen() {
     return this.fen;
@@ -65,12 +69,19 @@ const mockInitFn = vi.fn().mockResolvedValue(undefined);
 const mockGetLegalMoves = vi.fn().mockReturnValue(Array(20).fill("e2e4"));
 let mockGameInstance: MockChessGame;
 
+const mockNewFromFen = vi.fn((fen: string) => new MockChessGame(fen));
+
 vi.mock("../../../wasm-pkg/chess_wasm", () => ({
   default: mockInitFn,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ChessGame: function MockChessGameConstructor(this: any) {
-    return mockGameInstance;
-  },
+  ChessGame: Object.assign(
+    function MockChessGameConstructor(this: any) {
+      return mockGameInstance;
+    },
+    {
+      new_from_fen: (fen: string) => mockNewFromFen(fen),
+    }
+  ),
   get_legal_moves: mockGetLegalMoves,
 }));
 
@@ -88,6 +99,7 @@ beforeEach(async () => {
   mockPostMessage.mockClear();
   mockInitFn.mockClear().mockResolvedValue(undefined);
   mockGetLegalMoves.mockReturnValue(Array(20).fill("e2e4"));
+  mockNewFromFen.mockClear();
   mockGameInstance = new MockChessGame();
   const mod = await import("../chess.worker");
   handleMessage = mod.handleMessage;
@@ -197,7 +209,7 @@ describe("chess.worker message routing", () => {
       new MessageEvent("message", {
         data: {
           type: "INIT_FROM_EVENTS",
-          payload: { uciMoves: ["e2e4"] },
+          payload: { fenSnapshot: null, uciMoves: ["e2e4"] },
         },
       })
     );
@@ -217,12 +229,39 @@ describe("chess.worker message routing", () => {
       new MessageEvent("message", {
         data: {
           type: "INIT_FROM_EVENTS",
-          payload: { uciMoves: ["e2e9"] },
+          payload: { fenSnapshot: null, uciMoves: ["e2e9"] },
         },
       })
     );
     expect(mockPostMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: "ERROR" })
     );
+  });
+
+  it("uses new_from_fen when INIT_FROM_EVENTS has fenSnapshot", async () => {
+    await handleMessage(
+      new MessageEvent("message", {
+        data: {
+          type: "INIT_FROM_EVENTS",
+          payload: { fenSnapshot: AFTER_E2E4_FEN, uciMoves: [] },
+        },
+      })
+    );
+    expect(mockNewFromFen).toHaveBeenCalledWith(AFTER_E2E4_FEN);
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "STATE_UPDATE" })
+    );
+  });
+
+  it("does not call new_from_fen when fenSnapshot is null", async () => {
+    await handleMessage(
+      new MessageEvent("message", {
+        data: {
+          type: "INIT_FROM_EVENTS",
+          payload: { fenSnapshot: null, uciMoves: [] },
+        },
+      })
+    );
+    expect(mockNewFromFen).not.toHaveBeenCalled();
   });
 });

--- a/src/worker/chess.worker.ts
+++ b/src/worker/chess.worker.ts
@@ -15,10 +15,14 @@ function getRenderState(): RenderState {
   return game.render_state() as unknown as RenderState;
 }
 
-async function initWasm(): Promise<void> {
+async function initWasm(fenSnapshot?: string | null): Promise<void> {
   const mod = await import("../../wasm-pkg/chess_wasm");
   await mod.default();
-  game = new mod.ChessGame();
+  if (fenSnapshot) {
+    game = mod.ChessGame.new_from_fen(fenSnapshot) as ChessGameInstance;
+  } else {
+    game = new mod.ChessGame();
+  }
 }
 
 export async function handleMessage(
@@ -41,7 +45,7 @@ export async function handleMessage(
     }
     case "INIT_FROM_EVENTS": {
       try {
-        await initWasm();
+        await initWasm(data.payload.fenSnapshot);
         for (const move of data.payload.uciMoves) {
           game!.apply_move(move);
         }

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -2,7 +2,7 @@ import type { RenderState } from "../types/chess";
 
 export type WorkerRequest =
   | { type: "INIT" }
-  | { type: "INIT_FROM_EVENTS"; payload: { uciMoves: string[] } }
+  | { type: "INIT_FROM_EVENTS"; payload: { fenSnapshot: string | null; uciMoves: string[] } }
   | { type: "APPLY_MOVE"; payload: { uciMove: string } }
   | { type: "UNDO" }
   | { type: "REDO" }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -147,6 +147,19 @@ impl ChessGame {
         }
     }
 
+    pub fn new_from_fen(fen_str: &str) -> Result<ChessGame, JsValue> {
+        let fen: Fen = fen_str
+            .parse()
+            .map_err(|e| JsValue::from_str(&format!("invalid FEN: {}", e)))?;
+        let pos: Chess = fen
+            .into_position(CastlingMode::Standard)
+            .map_err(|e| JsValue::from_str(&format!("illegal position: {}", e)))?;
+        Ok(ChessGame {
+            history: vec![pos],
+            redo_stack: Vec::new(),
+        })
+    }
+
     pub fn current_fen(&self) -> String {
         Fen::from_position(self.current_pos().clone(), EnPassantMode::Legal).to_string()
     }


### PR DESCRIPTION
Closes #9

## Changes
- Add `ChessGame::new_from_fen()` to WASM for position restoration from FEN
- Add `saveSnapshot(fen)`, `loadGameState()`, `SNAPSHOT_INTERVAL=20` to storage utils
- `clearMoveEvents()` now also clears the FEN snapshot
- Extend `INIT_FROM_EVENTS` worker message to accept `fenSnapshot: string | null`
- `useChessWorker`: save FEN snapshot every 20 moves; restore from snapshot on reload

## Test
- cargo test: PASS
- bun run test (storage + worker): 23/23 PASS
- bun run build: PASS