### PR TITLE
bolt: WASM ChessGame::from_fen() + Worker INIT_FROM_FEN (#34)

### DIFF
--- a/src/worker/__tests__/chess.worker.test.ts
+++ b/src/worker/__tests__/chess.worker.test.ts
@@ -70,6 +70,10 @@ const mockGetLegalMoves = vi.fn().mockReturnValue(Array(20).fill("e2e4"));
 let mockGameInstance: MockChessGame;
 
 const mockNewFromFen = vi.fn((fen: string) => new MockChessGame(fen));
+const mockFromFen = vi.fn((fen: string) => {
+  if (fen === "invalid_fen") throw new Error("invalid FEN");
+  return new MockChessGame(fen);
+});
 
 vi.mock("../../../wasm-pkg/chess_wasm", () => ({
   default: mockInitFn,
@@ -80,6 +84,7 @@ vi.mock("../../../wasm-pkg/chess_wasm", () => ({
     },
     {
       new_from_fen: (fen: string) => mockNewFromFen(fen),
+      from_fen: (fen: string) => mockFromFen(fen),
     }
   ),
   get_legal_moves: mockGetLegalMoves,
@@ -100,6 +105,7 @@ beforeEach(async () => {
   mockInitFn.mockClear().mockResolvedValue(undefined);
   mockGetLegalMoves.mockReturnValue(Array(20).fill("e2e4"));
   mockNewFromFen.mockClear();
+  mockFromFen.mockClear();
   mockGameInstance = new MockChessGame();
   const mod = await import("../chess.worker");
   handleMessage = mod.handleMessage;
@@ -263,5 +269,39 @@ describe("chess.worker message routing", () => {
       })
     );
     expect(mockNewFromFen).not.toHaveBeenCalled();
+  });
+
+  it("responds STATE_UPDATE to INIT_FROM_FEN with valid FEN", async () => {
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "INIT_FROM_FEN", payload: { fen: AFTER_E2E4_FEN } },
+      })
+    );
+    expect(mockFromFen).toHaveBeenCalledWith(AFTER_E2E4_FEN);
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "STATE_UPDATE" })
+    );
+  });
+
+  it("responds ERROR to INIT_FROM_FEN with invalid FEN", async () => {
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "INIT_FROM_FEN", payload: { fen: "invalid_fen" } },
+      })
+    );
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "ERROR" })
+    );
+  });
+
+  it("does not write to localStorage on INIT_FROM_FEN", async () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+    await handleMessage(
+      new MessageEvent("message", {
+        data: { type: "INIT_FROM_FEN", payload: { fen: AFTER_E2E4_FEN } },
+      })
+    );
+    expect(setItemSpy).not.toHaveBeenCalled();
+    setItemSpy.mockRestore();
   });
 });

--- a/src/worker/chess.worker.ts
+++ b/src/worker/chess.worker.ts
@@ -112,6 +112,20 @@ export async function handleMessage(
       }
       break;
     }
+    case "INIT_FROM_FEN": {
+      try {
+        const mod = await import("../../wasm-pkg/chess_wasm");
+        await mod.default();
+        game = mod.ChessGame.from_fen(data.payload.fen) as ChessGameInstance;
+        postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
+      } catch (e) {
+        postResponse({
+          type: "ERROR",
+          payload: { message: String(e) },
+        });
+      }
+      break;
+    }
   }
 }
 

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -6,7 +6,8 @@ export type WorkerRequest =
   | { type: "APPLY_MOVE"; payload: { uciMove: string } }
   | { type: "UNDO" }
   | { type: "REDO" }
-  | { type: "RESET" };
+  | { type: "RESET" }
+  | { type: "INIT_FROM_FEN"; payload: { fen: string } };
 
 export type WorkerResponse =
   | { type: "STATE_UPDATE"; payload: RenderState }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -147,7 +147,7 @@ impl ChessGame {
         }
     }
 
-    pub fn new_from_fen(fen_str: &str) -> Result<ChessGame, JsValue> {
+    pub fn from_fen(fen_str: &str) -> Result<ChessGame, JsValue> {
         let fen: Fen = fen_str
             .parse()
             .map_err(|e| JsValue::from_str(&format!("invalid FEN: {}", e)))?;
@@ -158,6 +158,10 @@ impl ChessGame {
             history: vec![pos],
             redo_stack: Vec::new(),
         })
+    }
+
+    pub fn new_from_fen(fen_str: &str) -> Result<ChessGame, JsValue> {
+        ChessGame::from_fen(fen_str)
     }
 
     pub fn current_fen(&self) -> String {


### PR DESCRIPTION
Closes #34

## Changes
- Add `ChessGame::from_fen()` to WASM (static method to create game from FEN string)
- `new_from_fen()` now delegates to `from_fen()` for backward compat
- Add `INIT_FROM_FEN` worker message type `{ fen: string }`
- Worker handler: creates game from FEN without writing to localStorage
- 3 new tests for INIT_FROM_FEN (success, invalid FEN, no localStorage write)

## Test
- cargo test: 40/40 PASS
- bun run test (worker): 12/12 PASS
- bun run build: PASS