### PR TITLE
feat: Undo 時の localStorage イベント削除 (bolt-30)

### DIFF
--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -26,6 +26,8 @@ vi.mock("../../utils/storage", () => ({
   saveMoveEvent: vi.fn(),
   saveSnapshot: vi.fn(),
   clearMoveEvents: vi.fn(),
+  popMoveEvent: vi.fn(),
+  getMoveEventCount: vi.fn(() => 0),
   SNAPSHOT_INTERVAL: 20,
 }));
 

--- a/src/hooks/__tests__/useChessWorker.test.ts
+++ b/src/hooks/__tests__/useChessWorker.test.ts
@@ -224,6 +224,19 @@ describe("useChessWorker", () => {
       expect(spy).toHaveBeenCalledWith("e2e4");
     });
 
+    it("sendUndo calls popMoveEvent before posting UNDO", () => {
+      const popSpy = vi.spyOn(storage, "popMoveEvent").mockImplementation(() => {});
+      const { result } = renderHook(() => useChessWorker());
+
+      act(() => { sendStateUpdate(); });
+      workerInstance.postMessage.mockClear();
+
+      act(() => { result.current.sendUndo(); });
+
+      expect(popSpy).toHaveBeenCalled();
+      expect(workerInstance.postMessage).toHaveBeenCalledWith({ type: "UNDO" });
+    });
+
     it("resetGame clears localStorage and sends INIT", () => {
       const clearSpy = vi.spyOn(storage, "clearMoveEvents").mockImplementation(() => {});
       const { result } = renderHook(() => useChessWorker());

--- a/src/hooks/useChessWorker.ts
+++ b/src/hooks/useChessWorker.ts
@@ -7,6 +7,7 @@ import {
   saveSnapshot,
   loadGameState,
   clearMoveEvents,
+  popMoveEvent,
   SNAPSHOT_INTERVAL,
 } from "../utils/storage";
 
@@ -125,6 +126,7 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
   }, []);
 
   const sendUndo = useCallback(() => {
+    popMoveEvent();
     workerRef.current?.postMessage({ type: "UNDO" });
   }, []);
 

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -3,6 +3,8 @@ import {
   saveMoveEvent,
   loadMoveEvents,
   clearMoveEvents,
+  popMoveEvent,
+  getMoveEventCount,
   saveSnapshot,
   loadGameState,
   SNAPSHOT_INTERVAL,
@@ -95,6 +97,53 @@ describe("storage", () => {
     it("returns null fenSnapshot with moves when no snapshot", () => {
       saveMoveEvent("e2e4");
       expect(loadGameState()).toEqual({ fenSnapshot: null, uciMoves: ["e2e4"] });
+    });
+  });
+
+  describe("popMoveEvent", () => {
+    it("does nothing on empty storage", () => {
+      expect(() => popMoveEvent()).not.toThrow();
+      expect(loadMoveEvents()).toEqual([]);
+    });
+
+    it("removes the last event", () => {
+      saveMoveEvent("e2e4");
+      saveMoveEvent("e7e5");
+      popMoveEvent();
+      expect(loadMoveEvents()).toEqual(["e2e4"]);
+    });
+
+    it("removes only the last event when multiple exist", () => {
+      saveMoveEvent("e2e4");
+      saveMoveEvent("e7e5");
+      saveMoveEvent("d2d4");
+      popMoveEvent();
+      expect(loadMoveEvents()).toEqual(["e2e4", "e7e5"]);
+    });
+
+    it("leaves storage empty after removing last event", () => {
+      saveMoveEvent("e2e4");
+      popMoveEvent();
+      expect(loadMoveEvents()).toEqual([]);
+    });
+  });
+
+  describe("getMoveEventCount", () => {
+    it("returns 0 when empty", () => {
+      expect(getMoveEventCount()).toBe(0);
+    });
+
+    it("returns correct count after saves", () => {
+      saveMoveEvent("e2e4");
+      saveMoveEvent("e7e5");
+      expect(getMoveEventCount()).toBe(2);
+    });
+
+    it("decrements after pop", () => {
+      saveMoveEvent("e2e4");
+      saveMoveEvent("e7e5");
+      popMoveEvent();
+      expect(getMoveEventCount()).toBe(1);
     });
   });
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -42,3 +42,20 @@ export function clearMoveEvents(): void {
   localStorage.removeItem(STORAGE_KEY);
   localStorage.removeItem(SNAPSHOT_KEY);
 }
+
+export function popMoveEvent(): void {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const events = JSON.parse(raw);
+    if (!Array.isArray(events) || events.length === 0) return;
+    events.pop();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+  } catch {
+    // Corrupt storage — ignore
+  }
+}
+
+export function getMoveEventCount(): number {
+  return loadMoveEvents().length;
+}

--- a/src/worker/__tests__/chess.worker.test.ts
+++ b/src/worker/__tests__/chess.worker.test.ts
@@ -77,9 +77,8 @@ const mockFromFen = vi.fn((fen: string) => {
 
 vi.mock("../../../wasm-pkg/chess_wasm", () => ({
   default: mockInitFn,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ChessGame: Object.assign(
-    function MockChessGameConstructor(this: any) {
+    function MockChessGameConstructor(this: unknown) {
       return mockGameInstance;
     },
     {


### PR DESCRIPTION
Closes #68

## Changes
- `storage.ts`: `popMoveEvent()` 追加 — 末尾の move event を削除（undo に対応）
- `storage.ts`: `getMoveEventCount()` 追加 — テスト・デバッグ用
- `useChessWorker.ts`: `sendUndo` が Worker に UNDO を送る前に `popMoveEvent()` を呼ぶ
- テストファイル: `popMoveEvent`/`getMoveEventCount` のユニットテスト追加、`sendUndo` → `popMoveEvent` アサート追加
- 既存の壊れたテスト修正: `App.test.tsx` の storage モック更新（bolt-09 導入の `loadGameState` 対応）、`chess.worker.test.ts` ESLint any 型修正

## Test
- bun run test: PASS (113 tests)
- bun run lint: PASS