### PR TITLE
bolt: ドラッグ&ドロップ駒移動 (#36)

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,8 +1,10 @@
 import type { RenderState } from "../types/chess";
 import { parseFen } from "../utils/fen";
 import { useBoardInteraction } from "../hooks/useBoardInteraction";
+import { useDragDrop } from "../hooks/useDragDrop";
 import { Square } from "./Square";
 import { PromotionDialog } from "./PromotionDialog";
+import { Piece } from "./Piece";
 
 interface BoardProps {
   renderState: RenderState;
@@ -23,6 +25,9 @@ export function Board({ renderState, onMove, flipped }: BoardProps) {
     handlePromotionCancel,
   } = useBoardInteraction(renderState, onMove);
 
+  const { dragState, handlePointerDown, handlePointerMove, handlePointerUp } =
+    useDragDrop(renderState, onMove);
+
   const pieceMap = parseFen(renderState.fen);
 
   const ranks = flipped ? [...RANKS].reverse() : RANKS;
@@ -38,8 +43,12 @@ export function Board({ renderState, onMove, flipped }: BoardProps) {
           aspectRatio: "1",
           border: "2px solid #333",
           boxSizing: "border-box",
+          position: "relative",
+          touchAction: "none",
         }}
         aria-label="Chess board"
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
       >
         {ranks.map((rank) => (
           <div
@@ -48,19 +57,35 @@ export function Board({ renderState, onMove, flipped }: BoardProps) {
           >
             {files.map((file) => {
               const sq = `${file}${rank}`;
+              const isDragging = dragState.isDragging && dragState.draggedFrom === sq;
               return (
                 <Square
                   key={sq}
                   square={sq}
-                  piece={pieceMap.get(sq) ?? null}
+                  piece={isDragging ? null : (pieceMap.get(sq) ?? null)}
                   isSelected={selectedSquare === sq}
                   isLegalTarget={legalTargets.includes(sq)}
                   onClick={handleSquareClick}
+                  onPointerDown={handlePointerDown}
                 />
               );
             })}
           </div>
         ))}
+        {dragState.isDragging && dragState.draggedPiece && (
+          <div
+            style={{
+              position: "fixed",
+              left: dragState.dragX,
+              top: dragState.dragY,
+              transform: "translate(-50%, -50%)",
+              pointerEvents: "none",
+              zIndex: 1000,
+            }}
+          >
+            <Piece code={dragState.draggedPiece} />
+          </div>
+        )}
       </div>
       <PromotionDialog
         isOpen={pendingPromotion !== null}

--- a/src/components/Square.tsx
+++ b/src/components/Square.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { PieceCode, Square as SquareType } from "../utils/fen";
 import { Piece } from "./Piece";
 
@@ -7,6 +8,7 @@ interface SquareProps {
   isSelected: boolean;
   isLegalTarget: boolean;
   onClick: (square: SquareType) => void;
+  onPointerDown?: (event: React.PointerEvent<HTMLElement>, square: SquareType) => void;
 }
 
 export function Square({
@@ -15,6 +17,7 @@ export function Square({
   isSelected,
   isLegalTarget,
   onClick,
+  onPointerDown,
 }: SquareProps) {
   const file = square.charCodeAt(0) - "a".charCodeAt(0); // 0-7
   const rank = parseInt(square[1], 10) - 1; // 0-7
@@ -27,6 +30,7 @@ export function Square({
   return (
     <div
       onClick={() => onClick(square)}
+      onPointerDown={onPointerDown ? (e) => onPointerDown(e as React.PointerEvent<HTMLElement>, square) : undefined}
       style={{
         width: "12.5%",
         paddingBottom: "12.5%",

--- a/src/hooks/__tests__/useDragDrop.test.ts
+++ b/src/hooks/__tests__/useDragDrop.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDragDrop } from "../useDragDrop";
+import type { RenderState } from "../../types/chess";
+import { GameStatus } from "../../types/chess";
+
+const STARTING_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+const AFTER_E2E4_FEN = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+
+function makeRenderState(partial: Partial<RenderState> = {}): RenderState {
+  return {
+    fen: STARTING_FEN,
+    board: {},
+    legalMoves: ["e2e4", "e2e3", "d2d4"],
+    status: GameStatus.InProgress,
+    isCheck: false,
+    canUndo: false,
+    canRedo: false,
+    currentTurn: "white",
+    ...partial,
+  };
+}
+
+function makePointerEvent(
+  type: string,
+  props: Partial<React.PointerEvent<HTMLElement>>
+): React.PointerEvent<HTMLElement> {
+  const el = document.createElement("div");
+  el.setPointerCapture = vi.fn();
+  return {
+    pointerId: 1,
+    clientX: 0,
+    clientY: 0,
+    currentTarget: el,
+    target: el,
+    type,
+    ...props,
+  } as unknown as React.PointerEvent<HTMLElement>;
+}
+
+describe("useDragDrop", () => {
+  let onMove: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onMove = vi.fn();
+  });
+
+  it("starts with isDragging false", () => {
+    const { result } = renderHook(() =>
+      useDragDrop(makeRenderState(), onMove)
+    );
+    expect(result.current.dragState.isDragging).toBe(false);
+  });
+
+  it("sets isDragging true on pointerDown on own piece", () => {
+    const { result } = renderHook(() =>
+      useDragDrop(makeRenderState(), onMove)
+    );
+    act(() => {
+      result.current.handlePointerDown(makePointerEvent("pointerdown", {}), "e2");
+    });
+    expect(result.current.dragState.isDragging).toBe(true);
+    expect(result.current.dragState.draggedFrom).toBe("e2");
+  });
+
+  it("does not start drag on opponent piece", () => {
+    const { result } = renderHook(() =>
+      useDragDrop(makeRenderState(), onMove)
+    );
+    act(() => {
+      result.current.handlePointerDown(makePointerEvent("pointerdown", {}), "e7");
+    });
+    expect(result.current.dragState.isDragging).toBe(false);
+  });
+
+  it("does not start drag on empty square", () => {
+    const { result } = renderHook(() =>
+      useDragDrop(makeRenderState(), onMove)
+    );
+    act(() => {
+      result.current.handlePointerDown(makePointerEvent("pointerdown", {}), "e4");
+    });
+    expect(result.current.dragState.isDragging).toBe(false);
+  });
+
+  it("updates dragX/dragY on pointerMove", () => {
+    const { result } = renderHook(() =>
+      useDragDrop(makeRenderState(), onMove)
+    );
+    act(() => {
+      result.current.handlePointerDown(makePointerEvent("pointerdown", {}), "e2");
+    });
+    act(() => {
+      result.current.handlePointerMove(
+        makePointerEvent("pointermove", { clientX: 100, clientY: 200 })
+      );
+    });
+    expect(result.current.dragState.dragX).toBe(100);
+    expect(result.current.dragState.dragY).toBe(200);
+  });
+
+  it("calls onMove with legal UCI on pointerUp over valid target", () => {
+    const squareEl = document.createElement("div");
+    squareEl.setAttribute("data-square", "e4");
+    Object.defineProperty(document, "elementFromPoint", { configurable: true, writable: true, value: vi.fn().mockReturnValue(squareEl) });
+
+    const { result } = renderHook(() =>
+      useDragDrop(makeRenderState(), onMove)
+    );
+    act(() => {
+      result.current.handlePointerDown(makePointerEvent("pointerdown", {}), "e2");
+    });
+    act(() => {
+      result.current.handlePointerUp(makePointerEvent("pointerup", {}));
+    });
+    expect(onMove).toHaveBeenCalledWith("e2e4");
+    expect(result.current.dragState.isDragging).toBe(false);
+  });
+
+  it("does not call onMove on illegal target square", () => {
+    const squareEl = document.createElement("div");
+    squareEl.setAttribute("data-square", "e5");
+    Object.defineProperty(document, "elementFromPoint", { configurable: true, writable: true, value: vi.fn().mockReturnValue(squareEl) });
+
+    const { result } = renderHook(() =>
+      useDragDrop(makeRenderState(), onMove)
+    );
+    act(() => {
+      result.current.handlePointerDown(makePointerEvent("pointerdown", {}), "e2");
+    });
+    act(() => {
+      result.current.handlePointerUp(makePointerEvent("pointerup", {}));
+    });
+    expect(onMove).not.toHaveBeenCalled();
+    expect(result.current.dragState.isDragging).toBe(false);
+  });
+
+  it("auto-promotes pawn to queen when reaching rank 8", () => {
+    // White pawn on e7, legal move e7e8
+    const squareEl = document.createElement("div");
+    squareEl.setAttribute("data-square", "e8");
+    Object.defineProperty(document, "elementFromPoint", { configurable: true, writable: true, value: vi.fn().mockReturnValue(squareEl) });
+
+    const renderState = makeRenderState({
+      fen: "8/4P3/8/8/8/8/8/8 w - - 0 1",
+      legalMoves: ["e7e8q", "e7e8r", "e7e8b", "e7e8n"],
+    });
+
+    const { result } = renderHook(() => useDragDrop(renderState, onMove));
+    act(() => {
+      result.current.handlePointerDown(makePointerEvent("pointerdown", {}), "e7");
+    });
+    act(() => {
+      result.current.handlePointerUp(makePointerEvent("pointerup", {}));
+    });
+    expect(onMove).toHaveBeenCalledWith("e7e8q");
+  });
+
+  it("resets drag state on pointerUp regardless of move validity", () => {
+    Object.defineProperty(document, "elementFromPoint", { configurable: true, writable: true, value: vi.fn().mockReturnValue(null) });
+
+    const { result } = renderHook(() =>
+      useDragDrop(makeRenderState(), onMove)
+    );
+    act(() => {
+      result.current.handlePointerDown(makePointerEvent("pointerdown", {}), "e2");
+    });
+    act(() => {
+      result.current.handlePointerUp(makePointerEvent("pointerup", {}));
+    });
+    expect(result.current.dragState.isDragging).toBe(false);
+    expect(result.current.dragState.draggedFrom).toBeNull();
+  });
+});

--- a/src/hooks/useDragDrop.ts
+++ b/src/hooks/useDragDrop.ts
@@ -1,0 +1,104 @@
+import { useState, useCallback, useRef } from "react";
+import type { RenderState } from "../types/chess";
+import { getFenTurn, parseFen } from "../utils/fen";
+
+interface DragState {
+  isDragging: boolean;
+  draggedPiece: string | null;
+  draggedFrom: string | null;
+  dragX: number;
+  dragY: number;
+}
+
+const initialDragState: DragState = {
+  isDragging: false,
+  draggedPiece: null,
+  draggedFrom: null,
+  dragX: 0,
+  dragY: 0,
+};
+
+function buildUci(from: string, to: string, piece: string): string {
+  const isPromotion =
+    (piece === "P" && to[1] === "8") || (piece === "p" && to[1] === "1");
+  return isPromotion ? `${from}${to}q` : `${from}${to}`;
+}
+
+export function useDragDrop(
+  renderState: RenderState | null,
+  onMove: (uciMove: string) => void
+) {
+  const [dragState, setDragState] = useState<DragState>(initialDragState);
+  const pointerIdRef = useRef<number | null>(null);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>, square: string) => {
+      if (!renderState) return;
+      const turn = getFenTurn(renderState.fen);
+      const pieceMap = parseFen(renderState.fen);
+      const piece = pieceMap.get(square);
+      if (!piece) return;
+
+      const isWhitePiece = piece === piece.toUpperCase();
+      if (
+        (turn === "white" && !isWhitePiece) ||
+        (turn === "black" && isWhitePiece)
+      ) {
+        return;
+      }
+
+      event.currentTarget.setPointerCapture(event.pointerId);
+      pointerIdRef.current = event.pointerId;
+
+      setDragState({
+        isDragging: true,
+        draggedPiece: piece,
+        draggedFrom: square,
+        dragX: event.clientX,
+        dragY: event.clientY,
+      });
+    },
+    [renderState]
+  );
+
+  const handlePointerMove = useCallback((event: React.PointerEvent) => {
+    if (!dragState.isDragging) return;
+    setDragState((prev) => ({
+      ...prev,
+      dragX: event.clientX,
+      dragY: event.clientY,
+    }));
+  }, [dragState.isDragging]);
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent) => {
+      if (!dragState.isDragging || !dragState.draggedFrom || !dragState.draggedPiece) return;
+
+      const target = document.elementFromPoint(event.clientX, event.clientY);
+      const squareEl = target?.closest<HTMLElement>("[data-square]");
+      const toSquare = squareEl?.getAttribute("data-square");
+
+      if (toSquare && toSquare !== dragState.draggedFrom) {
+        const fromTo = `${dragState.draggedFrom}${toSquare}`;
+        const isLegal = renderState?.legalMoves.some((m) =>
+          m.startsWith(fromTo)
+        );
+        if (isLegal) {
+          const uci = buildUci(dragState.draggedFrom, toSquare, dragState.draggedPiece);
+          onMove(uci);
+        }
+      }
+
+      pointerIdRef.current = null;
+      setDragState(initialDragState);
+    },
+    [dragState, renderState, onMove]
+  );
+
+  return {
+    dragState,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+  };
+}


### PR DESCRIPTION
Closes #36

## Changes
- `useDragDrop` hook: pointer capture API, legal move validation via `legalMoves`, auto-promotes pawns to queen
- `Board.tsx`: integrates drag handlers on board wrapper, renders floating ghost piece during drag (piece hidden on source square)
- `Square.tsx`: added optional `onPointerDown` prop for drag initiation
- 9 unit tests covering all drag states and edge cases

## Test
- bun run test: 121/121 PASS
- bun run build: PASS