### PR TITLE
bolt-F: add last move highlight

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ function ChessApp({
     initState,
     renderState,
     lastError,
+    lastMove,
     sendMove,
     sendUndo,
     sendRedo,
@@ -127,6 +128,7 @@ function ChessApp({
             renderState={renderState}
             onMove={sendMove}
             flipped={flipped}
+            lastMove={lastMove}
           />
           <div style={{ display: "flex", gap: "8px" }}>
             <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,6 @@ function ChessApp({
     initState,
     renderState,
     lastError,
-    lastMove,
     sendMove,
     sendUndo,
     sendRedo,
@@ -128,7 +127,7 @@ function ChessApp({
             renderState={renderState}
             onMove={sendMove}
             flipped={flipped}
-            lastMove={lastMove}
+            lastMove={renderState.lastMove}
           />
           <div style={{ display: "flex", gap: "8px" }}>
             <button

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -10,12 +10,13 @@ interface BoardProps {
   renderState: RenderState;
   onMove: (uciMove: string) => void;
   flipped: boolean;
+  lastMove?: { from: string; to: string } | null;
 }
 
 const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
 const RANKS = [8, 7, 6, 5, 4, 3, 2, 1];
 
-export function Board({ renderState, onMove, flipped }: BoardProps) {
+export function Board({ renderState, onMove, flipped, lastMove }: BoardProps) {
   const {
     selectedSquare,
     legalTargets,
@@ -69,6 +70,7 @@ export function Board({ renderState, onMove, flipped }: BoardProps) {
                   onPointerDown={handlePointerDown}
                   rankLabel={fileIdx === 0 ? String(rank) : undefined}
                   fileLabel={rankIdx === ranks.length - 1 ? file : undefined}
+                  isLastMove={sq === lastMove?.from || sq === lastMove?.to}
                 />
               );
             })}

--- a/src/components/Square.tsx
+++ b/src/components/Square.tsx
@@ -11,6 +11,7 @@ interface SquareProps {
   onPointerDown?: (event: React.PointerEvent<HTMLElement>, square: SquareType) => void;
   rankLabel?: string;
   fileLabel?: string;
+  isLastMove?: boolean;
 }
 
 export function Square({
@@ -22,6 +23,7 @@ export function Square({
   onPointerDown,
   rankLabel,
   fileLabel,
+  isLastMove,
 }: SquareProps) {
   const file = square.charCodeAt(0) - "a".charCodeAt(0); // 0-7
   const rank = parseInt(square[1], 10) - 1; // 0-7
@@ -30,6 +32,7 @@ export function Square({
   let bg = isLight ? "#f0d9b5" : "#b58863";
   if (isSelected) bg = "#f6f669";
   else if (isLegalTarget) bg = isLight ? "#cdd26a" : "#aaa23a";
+  else if (isLastMove) bg = isLight ? "#f6f632" : "#c9c93a";
 
   const labelStyle: React.CSSProperties = {
     position: "absolute",

--- a/src/components/Square.tsx
+++ b/src/components/Square.tsx
@@ -30,16 +30,17 @@ export function Square({
   const isLight = (file + rank) % 2 === 1;
 
   let bg = isLight ? "#f0d9b5" : "#b58863";
-  if (isSelected) bg = "#f6f669";
-  else if (isLegalTarget) bg = isLight ? "#cdd26a" : "#aaa23a";
-  else if (isLastMove) bg = isLight ? "#f6f632" : "#c9c93a";
+  let bgIsLight = isLight;
+  if (isSelected) { bg = "#f6f669"; bgIsLight = true; }
+  else if (isLegalTarget) { bg = isLight ? "#cdd26a" : "#aaa23a"; }
+  else if (isLastMove) { bg = isLight ? "#e8e87a" : "#b5b54a"; bgIsLight = isLight; }
 
   const labelStyle: React.CSSProperties = {
     position: "absolute",
     fontSize: "13px",
     lineHeight: 1,
     fontWeight: 700,
-    color: isLight ? "#1a1a1a" : "#f5f5f5",
+    color: bgIsLight ? "#1a1a1a" : "#f5f5f5",
     pointerEvents: "none",
     userSelect: "none",
     zIndex: 1,

--- a/src/components/Square.tsx
+++ b/src/components/Square.tsx
@@ -23,7 +23,7 @@ export function Square({
   onPointerDown,
   rankLabel,
   fileLabel,
-  isLastMove,
+  isLastMove = false,
 }: SquareProps) {
   const file = square.charCodeAt(0) - "a".charCodeAt(0); // 0-7
   const rank = parseInt(square[1], 10) - 1; // 0-7

--- a/src/components/__tests__/BoardCoordinates.test.tsx
+++ b/src/components/__tests__/BoardCoordinates.test.tsx
@@ -21,6 +21,7 @@ function makeRenderState(overrides?: Partial<RenderState>): RenderState {
     canUndo: false,
     canRedo: false,
     currentTurn: "white",
+    lastMove: null,
     board: {},
     ...overrides,
   };

--- a/src/hooks/__tests__/useBoardInteraction.test.ts
+++ b/src/hooks/__tests__/useBoardInteraction.test.ts
@@ -16,6 +16,7 @@ function makeRenderState(overrides?: Partial<RenderState>): RenderState {
     canUndo: false,
     canRedo: false,
     currentTurn: "white",
+    lastMove: null,
     ...overrides,
   };
 }

--- a/src/hooks/__tests__/useChessWorker.test.ts
+++ b/src/hooks/__tests__/useChessWorker.test.ts
@@ -39,6 +39,7 @@ const INIT_STATE_UPDATE: WorkerResponse = {
     canUndo: false,
     canRedo: false,
     currentTurn: "white",
+    lastMove: null,
   },
 };
 
@@ -156,6 +157,7 @@ describe("useChessWorker", () => {
               canUndo: false,
               canRedo: false,
               currentTurn: "white" as const,
+              lastMove: null,
             },
           },
         })
@@ -171,6 +173,7 @@ describe("useChessWorker", () => {
       canUndo: false,
       canRedo: false,
       currentTurn: "white",
+      lastMove: null,
     });
     expect(result.current.initState).toBe("ready");
   });
@@ -320,61 +323,48 @@ describe("useChessWorker", () => {
     });
   });
 
-  describe("lastMove", () => {
-    it("is null on initial load", () => {
-      const { result } = renderHook(() => useChessWorker());
-      expect(result.current.lastMove).toBeNull();
-    });
-
-    it("is set to from/to after sendMove", () => {
+  describe("lastMove (from Worker RenderState)", () => {
+    it("is null on initial STATE_UPDATE", () => {
       const { result } = renderHook(() => useChessWorker());
       act(() => { sendStateUpdate(); });
 
-      act(() => { result.current.sendMove("e2e4"); });
-
-      expect(result.current.lastMove).toEqual({ from: "e2", to: "e4" });
+      expect(result.current.renderState?.lastMove).toBeNull();
     });
 
-    it("extracts correct squares from promotion move (5-char UCI)", () => {
+    it("reflects Worker lastMove after APPLY_MOVE response", () => {
       const { result } = renderHook(() => useChessWorker());
       act(() => { sendStateUpdate(); });
 
-      act(() => { result.current.sendMove("e7e8q"); });
+      act(() => {
+        result.current.sendMove("e2e4");
+        // Simulate Worker response with lastMove set
+        sendStateUpdate({
+          type: "STATE_UPDATE",
+          payload: {
+            ...INIT_STATE_UPDATE.payload as RenderState,
+            lastMove: { from: "e2", to: "e4" },
+          },
+        });
+      });
 
-      expect(result.current.lastMove).toEqual({ from: "e7", to: "e8" });
+      expect(result.current.renderState?.lastMove).toEqual({ from: "e2", to: "e4" });
     });
 
-    it("is null after sendUndo", () => {
+    it("is null after UNDO response", () => {
       const { result } = renderHook(() => useChessWorker());
       act(() => { sendStateUpdate(); });
-      act(() => { result.current.sendMove("e2e4"); });
-      expect(result.current.lastMove).not.toBeNull();
 
-      act(() => { result.current.sendUndo(); });
+      act(() => {
+        sendStateUpdate({
+          type: "STATE_UPDATE",
+          payload: {
+            ...INIT_STATE_UPDATE.payload as RenderState,
+            lastMove: null,
+          },
+        });
+      });
 
-      expect(result.current.lastMove).toBeNull();
-    });
-
-    it("is null after sendRedo", () => {
-      const { result } = renderHook(() => useChessWorker());
-      act(() => { sendStateUpdate(); });
-      act(() => { result.current.sendMove("e2e4"); });
-
-      act(() => { result.current.sendRedo(); });
-
-      expect(result.current.lastMove).toBeNull();
-    });
-
-    it("is null after resetGame", () => {
-      vi.spyOn(storage, "clearMoveEvents").mockImplementation(() => {});
-      const { result } = renderHook(() => useChessWorker());
-      act(() => { sendStateUpdate(); });
-      act(() => { result.current.sendMove("e2e4"); });
-      expect(result.current.lastMove).not.toBeNull();
-
-      act(() => { result.current.resetGame(); });
-
-      expect(result.current.lastMove).toBeNull();
+      expect(result.current.renderState?.lastMove).toBeNull();
     });
   });
 });

--- a/src/hooks/__tests__/useChessWorker.test.ts
+++ b/src/hooks/__tests__/useChessWorker.test.ts
@@ -319,4 +319,62 @@ describe("useChessWorker", () => {
       expect(workerInstance.postMessage).toHaveBeenCalledWith({ type: "INIT" });
     });
   });
+
+  describe("lastMove", () => {
+    it("is null on initial load", () => {
+      const { result } = renderHook(() => useChessWorker());
+      expect(result.current.lastMove).toBeNull();
+    });
+
+    it("is set to from/to after sendMove", () => {
+      const { result } = renderHook(() => useChessWorker());
+      act(() => { sendStateUpdate(); });
+
+      act(() => { result.current.sendMove("e2e4"); });
+
+      expect(result.current.lastMove).toEqual({ from: "e2", to: "e4" });
+    });
+
+    it("extracts correct squares from promotion move (5-char UCI)", () => {
+      const { result } = renderHook(() => useChessWorker());
+      act(() => { sendStateUpdate(); });
+
+      act(() => { result.current.sendMove("e7e8q"); });
+
+      expect(result.current.lastMove).toEqual({ from: "e7", to: "e8" });
+    });
+
+    it("is null after sendUndo", () => {
+      const { result } = renderHook(() => useChessWorker());
+      act(() => { sendStateUpdate(); });
+      act(() => { result.current.sendMove("e2e4"); });
+      expect(result.current.lastMove).not.toBeNull();
+
+      act(() => { result.current.sendUndo(); });
+
+      expect(result.current.lastMove).toBeNull();
+    });
+
+    it("is null after sendRedo", () => {
+      const { result } = renderHook(() => useChessWorker());
+      act(() => { sendStateUpdate(); });
+      act(() => { result.current.sendMove("e2e4"); });
+
+      act(() => { result.current.sendRedo(); });
+
+      expect(result.current.lastMove).toBeNull();
+    });
+
+    it("is null after resetGame", () => {
+      vi.spyOn(storage, "clearMoveEvents").mockImplementation(() => {});
+      const { result } = renderHook(() => useChessWorker());
+      act(() => { sendStateUpdate(); });
+      act(() => { result.current.sendMove("e2e4"); });
+      expect(result.current.lastMove).not.toBeNull();
+
+      act(() => { result.current.resetGame(); });
+
+      expect(result.current.lastMove).toBeNull();
+    });
+  });
 });

--- a/src/hooks/__tests__/useDragDrop.test.ts
+++ b/src/hooks/__tests__/useDragDrop.test.ts
@@ -16,6 +16,7 @@ function makeRenderState(partial: Partial<RenderState> = {}): RenderState {
     canUndo: false,
     canRedo: false,
     currentTurn: "white",
+    lastMove: null,
     ...partial,
   };
 }

--- a/src/hooks/__tests__/workerReducer.test.ts
+++ b/src/hooks/__tests__/workerReducer.test.ts
@@ -13,6 +13,7 @@ const mockRenderState: RenderState = {
   canUndo: false,
   canRedo: false,
   currentTurn: "white",
+  lastMove: null,
 };
 
 describe("useChessWorker reducer", () => {

--- a/src/hooks/useChessWorker.ts
+++ b/src/hooks/useChessWorker.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useRef } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import type { RenderState } from "../types/chess";
 import type { WorkerResponse } from "../worker/types";
 import ChessWorker from "../worker/chess.worker?worker";
@@ -75,7 +75,7 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
   const workerRef = useRef<InstanceType<typeof ChessWorker> | null>(null);
   const moveCountRef = useRef(0);
   const pendingSnapshotRef = useRef(false);
-  const lastMoveRef = useRef<{ from: string; to: string } | null>(null);
+  const [lastMove, setLastMove] = useState<{ from: string; to: string } | null>(null);
 
   useEffect(() => {
     const worker = new ChessWorker();
@@ -126,7 +126,7 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
     if (moveCountRef.current % SNAPSHOT_INTERVAL === 0) {
       pendingSnapshotRef.current = true;
     }
-    lastMoveRef.current = { from: uciMove.slice(0, 2), to: uciMove.slice(2, 4) };
+    setLastMove({ from: uciMove.slice(0, 2), to: uciMove.slice(2, 4) });
     workerRef.current?.postMessage({
       type: "APPLY_MOVE",
       payload: { uciMove },
@@ -135,12 +135,12 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
 
   const sendUndo = useCallback(() => {
     popMoveEvent();
-    lastMoveRef.current = null;
+    setLastMove(null);
     workerRef.current?.postMessage({ type: "UNDO" });
   }, []);
 
   const sendRedo = useCallback(() => {
-    lastMoveRef.current = null;
+    setLastMove(null);
     workerRef.current?.postMessage({ type: "REDO" });
   }, []);
 
@@ -156,7 +156,7 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
     clearMoveEvents();
     moveCountRef.current = 0;
     pendingSnapshotRef.current = false;
-    lastMoveRef.current = null;
+    setLastMove(null);
     dispatch({ type: "RESET" });
     workerRef.current?.postMessage({ type: "INIT" });
   }, []);
@@ -165,7 +165,7 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
     initState: state.initState,
     renderState: state.renderState,
     lastError: state.lastError,
-    lastMove: lastMoveRef.current,
+    lastMove,
     sendMove,
     sendUndo,
     sendRedo,

--- a/src/hooks/useChessWorker.ts
+++ b/src/hooks/useChessWorker.ts
@@ -62,6 +62,7 @@ export interface UseChessWorkerReturn {
   initState: InitState;
   renderState: RenderState | null;
   lastError: string | null;
+  lastMove: { from: string; to: string } | null;
   sendMove: (uciMove: string) => void;
   sendUndo: () => void;
   sendRedo: () => void;
@@ -74,6 +75,7 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
   const workerRef = useRef<InstanceType<typeof ChessWorker> | null>(null);
   const moveCountRef = useRef(0);
   const pendingSnapshotRef = useRef(false);
+  const lastMoveRef = useRef<{ from: string; to: string } | null>(null);
 
   useEffect(() => {
     const worker = new ChessWorker();
@@ -124,6 +126,7 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
     if (moveCountRef.current % SNAPSHOT_INTERVAL === 0) {
       pendingSnapshotRef.current = true;
     }
+    lastMoveRef.current = { from: uciMove.slice(0, 2), to: uciMove.slice(2, 4) };
     workerRef.current?.postMessage({
       type: "APPLY_MOVE",
       payload: { uciMove },
@@ -132,10 +135,12 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
 
   const sendUndo = useCallback(() => {
     popMoveEvent();
+    lastMoveRef.current = null;
     workerRef.current?.postMessage({ type: "UNDO" });
   }, []);
 
   const sendRedo = useCallback(() => {
+    lastMoveRef.current = null;
     workerRef.current?.postMessage({ type: "REDO" });
   }, []);
 
@@ -151,6 +156,7 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
     clearMoveEvents();
     moveCountRef.current = 0;
     pendingSnapshotRef.current = false;
+    lastMoveRef.current = null;
     dispatch({ type: "RESET" });
     workerRef.current?.postMessage({ type: "INIT" });
   }, []);
@@ -159,6 +165,7 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
     initState: state.initState,
     renderState: state.renderState,
     lastError: state.lastError,
+    lastMove: lastMoveRef.current,
     sendMove,
     sendUndo,
     sendRedo,

--- a/src/hooks/useChessWorker.ts
+++ b/src/hooks/useChessWorker.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import type { RenderState } from "../types/chess";
 import type { WorkerResponse } from "../worker/types";
 import ChessWorker from "../worker/chess.worker?worker";
@@ -62,7 +62,6 @@ export interface UseChessWorkerReturn {
   initState: InitState;
   renderState: RenderState | null;
   lastError: string | null;
-  lastMove: { from: string; to: string } | null;
   sendMove: (uciMove: string) => void;
   sendUndo: () => void;
   sendRedo: () => void;
@@ -75,7 +74,6 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
   const workerRef = useRef<InstanceType<typeof ChessWorker> | null>(null);
   const moveCountRef = useRef(0);
   const pendingSnapshotRef = useRef(false);
-  const [lastMove, setLastMove] = useState<{ from: string; to: string } | null>(null);
 
   useEffect(() => {
     const worker = new ChessWorker();
@@ -126,7 +124,6 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
     if (moveCountRef.current % SNAPSHOT_INTERVAL === 0) {
       pendingSnapshotRef.current = true;
     }
-    setLastMove({ from: uciMove.slice(0, 2), to: uciMove.slice(2, 4) });
     workerRef.current?.postMessage({
       type: "APPLY_MOVE",
       payload: { uciMove },
@@ -135,12 +132,10 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
 
   const sendUndo = useCallback(() => {
     popMoveEvent();
-    setLastMove(null);
     workerRef.current?.postMessage({ type: "UNDO" });
   }, []);
 
   const sendRedo = useCallback(() => {
-    setLastMove(null);
     workerRef.current?.postMessage({ type: "REDO" });
   }, []);
 
@@ -156,7 +151,6 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
     clearMoveEvents();
     moveCountRef.current = 0;
     pendingSnapshotRef.current = false;
-    setLastMove(null);
     dispatch({ type: "RESET" });
     workerRef.current?.postMessage({ type: "INIT" });
   }, []);
@@ -165,7 +159,6 @@ export function useChessWorker(initialFen?: string): UseChessWorkerReturn {
     initState: state.initState,
     renderState: state.renderState,
     lastError: state.lastError,
-    lastMove,
     sendMove,
     sendUndo,
     sendRedo,

--- a/src/types/__tests__/chess.test.ts
+++ b/src/types/__tests__/chess.test.ts
@@ -35,6 +35,7 @@ describe("RenderState", () => {
       canUndo: false,
       canRedo: false,
       currentTurn: "white",
+      lastMove: null,
     };
     expect(state.fen).toBeTruthy();
     expect(state.board).toEqual({ e1: "K", d1: "Q" });

--- a/src/types/chess.ts
+++ b/src/types/chess.ts
@@ -14,4 +14,5 @@ export interface RenderState {
   canUndo: boolean;
   canRedo: boolean;
   currentTurn: "white" | "black";
+  lastMove: { from: string; to: string } | null;
 }

--- a/src/worker/__tests__/chess.worker.test.ts
+++ b/src/worker/__tests__/chess.worker.test.ts
@@ -61,6 +61,7 @@ class MockChessGame {
       canUndo: this.can_undo(),
       canRedo: this.can_redo(),
       currentTurn: "white" as const,
+      lastMove: null,
     };
   }
 }

--- a/src/worker/__tests__/reset.test.ts
+++ b/src/worker/__tests__/reset.test.ts
@@ -30,6 +30,7 @@ class MockChessGame {
       canUndo: this.can_undo(),
       canRedo: this.can_redo(),
       currentTurn: "white" as const,
+      lastMove: null,
     };
   }
 }

--- a/src/worker/chess.worker.ts
+++ b/src/worker/chess.worker.ts
@@ -6,6 +6,7 @@ type WasmModule = typeof import("../../wasm-pkg/chess_wasm");
 type ChessGameInstance = InstanceType<WasmModule["ChessGame"]>;
 
 let game: ChessGameInstance | null = null;
+let lastMove: { from: string; to: string } | null = null;
 
 function postResponse(response: WorkerResponse): void {
   postMessage(response);
@@ -13,7 +14,9 @@ function postResponse(response: WorkerResponse): void {
 
 function getRenderState(): RenderState {
   if (!game) throw new Error("Game not initialized");
-  return game.render_state() as unknown as RenderState;
+  const state = game.render_state() as unknown as RenderState;
+  state.lastMove = lastMove;
+  return state;
 }
 
 async function initWasm(fenSnapshot?: string | null): Promise<void> {
@@ -35,6 +38,7 @@ export async function handleMessage(
     case "INIT": {
       try {
         await initWasm();
+        lastMove = null;
         postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({
@@ -47,8 +51,15 @@ export async function handleMessage(
     case "INIT_FROM_EVENTS": {
       try {
         await initWasm(data.payload.fenSnapshot);
-        for (const move of data.payload.uciMoves) {
+        const moves = data.payload.uciMoves;
+        for (const move of moves) {
           game!.apply_move(move);
+        }
+        if (moves.length > 0) {
+          const last = moves[moves.length - 1];
+          lastMove = { from: last.slice(0, 2), to: last.slice(2, 4) };
+        } else {
+          lastMove = null;
         }
         postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
@@ -62,7 +73,9 @@ export async function handleMessage(
     case "APPLY_MOVE": {
       try {
         if (!game) throw new Error("Game not initialized");
-        game.apply_move(data.payload.uciMove);
+        const uci = data.payload.uciMove;
+        game.apply_move(uci);
+        lastMove = { from: uci.slice(0, 2), to: uci.slice(2, 4) };
         postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({
@@ -76,6 +89,7 @@ export async function handleMessage(
       try {
         if (!game) throw new Error("Game not initialized");
         game.undo();
+        lastMove = null;
         postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({
@@ -89,6 +103,7 @@ export async function handleMessage(
       try {
         if (!game) throw new Error("Game not initialized");
         game.redo();
+        lastMove = null;
         postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({
@@ -103,6 +118,7 @@ export async function handleMessage(
         if (!game) throw new Error("Game not initialized");
         game.reset();
         clearMoveEvents();
+        lastMove = null;
         postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({
@@ -117,6 +133,7 @@ export async function handleMessage(
         const mod = await import("../../wasm-pkg/chess_wasm");
         await mod.default();
         game = mod.ChessGame.from_fen(data.payload.fen) as ChessGameInstance;
+        lastMove = null;
         postResponse({ type: "STATE_UPDATE", payload: getRenderState() });
       } catch (e) {
         postResponse({


### PR DESCRIPTION
Closes #86

## Changes
- Add `lastMove` field to `RenderState` type and track in Worker layer (WASM-as-source-of-truth)
- Highlight from/to squares of the most recent move with subtle yellow tint
- `isLastMove` prop in Square with proper priority: isSelected > isLegalTarget > isLastMove > default
- Worker tracks lastMove: set on APPLY_MOVE, restore on INIT_FROM_EVENTS, clear on INIT/UNDO/REDO/RESET
- Dynamic `bgIsLight` for coordinate label contrast on highlighted squares
- 3 hook-level tests + all fixture updates

## Test
- `bun run test`: 151 passed
- `bun run build`: PASS

https://claude.ai/code/session_01Lord23DKgSPXv4Cbxs4sXU